### PR TITLE
Add candidate auth & UI flow, HR permissions, job-application template assignment, and related tests

### DIFF
--- a/apps/backend/candidates/serializers/candidate.py
+++ b/apps/backend/candidates/serializers/candidate.py
@@ -1,5 +1,7 @@
-from django.db import IntegrityError
+from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import IntegrityError
+from django.db import transaction
 from rest_framework import serializers
 
 from candidates.models import Candidate
@@ -7,14 +9,19 @@ from users.models import User
 
 
 class CandidateUserSerializer(serializers.ModelSerializer):
-    first_name = serializers.CharField(required=True, allow_blank=False)
-    last_name = serializers.CharField(required=True, allow_blank=False)
+    first_name = serializers.CharField(required=True, allow_blank=False, max_length=150)
+    last_name = serializers.CharField(required=True, allow_blank=False, max_length=150)
     email = serializers.EmailField(required=True)
-    phone = serializers.CharField(required=False, allow_blank=True)
+    phone = serializers.CharField(required=False, allow_blank=True, max_length=32)
+    password = serializers.CharField(required=False, write_only=True, min_length=8)
 
     class Meta:
         model = User
-        fields = ["first_name", "last_name", "email", "phone"]
+        fields = ["first_name", "last_name", "email", "phone", "password"]
+
+    def validate_password(self, value: str) -> str:
+        validate_password(value)
+        return value
 
 
 class CandidateSerializer(serializers.ModelSerializer):
@@ -33,35 +40,61 @@ class CandidateSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_at", "updated_at"]
 
+    @staticmethod
+    def _email_already_used_error() -> serializers.ValidationError:
+        return serializers.ValidationError(
+            {"user": {"email": ["This email is already used."]}}
+        )
+
+    @staticmethod
+    def _password_validation_error(
+        error: DjangoValidationError,
+    ) -> serializers.ValidationError:
+        return serializers.ValidationError({"user": {"password": list(error.messages)}})
+
     def create(self, validated_data):
         user_data = validated_data.pop("user")
+        raw_password = user_data.pop("password", None)
 
-        try:
-            user = User.objects.create_user(
-                email=user_data["email"],
-                password=None,
-                first_name=user_data.get("first_name", ""),
-                last_name=user_data.get("last_name", ""),
-                phone=user_data.get("phone", ""),
-            )
-        except (IntegrityError, DjangoValidationError):
-            raise serializers.ValidationError(
-                {"user": {"email": ["This email is already used."]}}
-            )
+        with transaction.atomic():
+            try:
+                user = User.objects.create_user(
+                    email=user_data["email"],
+                    password=raw_password,
+                    first_name=user_data.get("first_name", ""),
+                    last_name=user_data.get("last_name", ""),
+                    phone=user_data.get("phone", ""),
+                )
+            except IntegrityError:
+                raise self._email_already_used_error()
 
-        return Candidate.objects.create(user=user, **validated_data)
+            return Candidate.objects.create(user=user, **validated_data)
 
     def update(self, instance, validated_data):
         user_data = validated_data.pop("user", None)
 
-        for attr, value in validated_data.items():
-            setattr(instance, attr, value)
-        instance.save()
+        with transaction.atomic():
+            for attr, value in validated_data.items():
+                setattr(instance, attr, value)
+            instance.save()
 
-        if user_data:
-            user = instance.user
-            for attr, value in user_data.items():
-                setattr(user, attr, value)
-            user.save()
+            if user_data:
+                user = instance.user
+                raw_password = user_data.pop("password", None)
 
-        return instance
+                for attr, value in user_data.items():
+                    setattr(user, attr, value)
+
+                if raw_password:
+                    try:
+                        validate_password(raw_password, user=user)
+                    except DjangoValidationError as error:
+                        raise self._password_validation_error(error)
+                    user.set_password(raw_password)
+
+                try:
+                    user.save()
+                except IntegrityError:
+                    raise self._email_already_used_error()
+
+            return instance

--- a/apps/backend/candidates/views/candidate.py
+++ b/apps/backend/candidates/views/candidate.py
@@ -1,6 +1,8 @@
 from rest_framework.viewsets import ModelViewSet
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from candidates.models import Candidate
 from candidates.serializers import CandidateSerializer
+from users.permissions import IsHrAdminOrDirector
 
 
 class CandidateViewSet(ModelViewSet):
@@ -8,3 +10,12 @@ class CandidateViewSet(ModelViewSet):
         Candidate.objects.select_related("user", "target_position").all().order_by("id")
     )
     serializer_class = CandidateSerializer
+
+    def get_permissions(self):
+        if self.action == "create":
+            return [AllowAny()]
+
+        if self.action in ["list", "retrieve", "update", "partial_update", "destroy"]:
+            return [IsAuthenticated(), IsHrAdminOrDirector()]
+
+        return [IsAuthenticated()]

--- a/apps/backend/core/urls.py
+++ b/apps/backend/core/urls.py
@@ -18,7 +18,7 @@ from evaluations.views import EvaluationViewSet
 router = DefaultRouter()
 router.register("companies", CompanyViewSet, basename="companies")
 router.register("positions", PositionViewSet, basename="positions")
-router.register(r'public/positions', PublicPositionViewSet, basename='public-positions')
+router.register(r"public/positions", PublicPositionViewSet, basename="public-positions")
 router.register("candidates", CandidateViewSet, basename="candidates")
 router.register("employees", EmployeeViewSet, basename="employees")
 router.register("jobapplications", JobApplicationViewSet, basename="jobapplications")

--- a/apps/backend/evaluations/serializers/__init__.py
+++ b/apps/backend/evaluations/serializers/__init__.py
@@ -1,5 +1,9 @@
 from .answer import SkillAnswerSerializer as SkillAnswerSerializer
+from .evaluation import AssignEvaluationSerializer as AssignEvaluationSerializer
 from .evaluation import EvaluationSerializer as EvaluationSerializer
-from .evaluation import StartEvaluationSerializer as StartEvaluationSerializer
 
-__all__ = ["SkillAnswerSerializer", "EvaluationSerializer", "StartEvaluationSerializer"]
+__all__ = [
+    "SkillAnswerSerializer",
+    "EvaluationSerializer",
+    "AssignEvaluationSerializer",
+]

--- a/apps/backend/evaluations/serializers/evaluation.py
+++ b/apps/backend/evaluations/serializers/evaluation.py
@@ -1,8 +1,6 @@
 from rest_framework import serializers
 from evaluations.models import Evaluation
-from candidates.models import Candidate
-from templates_grid.models import Template
-from users.models import User
+from evaluations.services.assign_test import AssignTestToApplicationService
 
 
 class EvaluationSerializer(serializers.ModelSerializer):
@@ -32,34 +30,17 @@ class EvaluationSerializer(serializers.ModelSerializer):
         ]
 
 
-class StartEvaluationSerializer(serializers.Serializer):
-    candidate_id = serializers.IntegerField(required=True)
-    grid_id = serializers.IntegerField(required=True)
+class AssignEvaluationSerializer(serializers.Serializer):
+    application_id = serializers.IntegerField(required=True)
     evaluator_id = serializers.IntegerField(required=True)
-
-    def validate(self, data):
-        # Vérifier existence des objets
-        try:
-            data["candidate"] = Candidate.objects.get(id=data["candidate_id"])
-        except Candidate.DoesNotExist:
-            raise serializers.ValidationError({"candidate_id": "Invalid candidate_id"})
-
-        try:
-            data["template"] = Template.objects.get(id=data["grid_id"])
-        except Template.DoesNotExist:
-            raise serializers.ValidationError({"grid_id": "Invalid grid_id"})
-
-        try:
-            data["evaluator"] = User.objects.get(id=data["evaluator_id"])
-        except User.DoesNotExist:
-            raise serializers.ValidationError({"evaluator_id": "Invalid evaluator_id"})
-
-        return data
+    template_id = serializers.IntegerField(required=False)
 
     def create(self, validated_data):
-        return Evaluation.objects.create(
-            candidate=validated_data["candidate"],
-            template=validated_data["template"],
-            assigned_to=validated_data["evaluator"],
-            status="in_progress",
+        return AssignTestToApplicationService.execute(
+            application_id=validated_data["application_id"],
+            evaluator_id=validated_data["evaluator_id"],
+            template_id=validated_data.get("template_id"),
         )
+
+    def to_representation(self, instance: Evaluation):
+        return EvaluationSerializer(instance).data

--- a/apps/backend/evaluations/services/assign_test.py
+++ b/apps/backend/evaluations/services/assign_test.py
@@ -1,0 +1,78 @@
+from django.db import transaction
+from rest_framework import serializers
+
+from evaluations.models import Evaluation
+from recruitment.models import JobApplication
+from templates_grid.models import Template, TemplateVersion
+from users.models import User, UserRoles
+
+
+class AssignTestToApplicationService:
+    @staticmethod
+    @transaction.atomic
+    def execute(
+        *,
+        application_id: int,
+        evaluator_id: int,
+        template_id: int | None = None,
+    ) -> Evaluation:
+        application = (
+            JobApplication.objects.select_related(
+                "candidate__user", "position", "assigned_template"
+            )
+            .filter(id=application_id)
+            .first()
+        )
+        if application is None:
+            raise serializers.ValidationError(
+                {"application_id": "Invalid application_id"}
+            )
+
+        evaluator = User.objects.filter(id=evaluator_id).first()
+        if evaluator is None:
+            raise serializers.ValidationError({"evaluator_id": "Invalid evaluator_id"})
+        if evaluator.role != UserRoles.MANAGER:
+            raise serializers.ValidationError(
+                {"evaluator_id": "Evaluator must have manager role"}
+            )
+
+        template = None
+        if template_id is not None:
+            template = Template.objects.filter(id=template_id).first()
+            if template is None:
+                raise serializers.ValidationError(
+                    {"template_id": "Invalid template_id"}
+                )
+        else:
+            template = application.assigned_template
+
+        if template is None:
+            raise serializers.ValidationError(
+                {"template_id": "No template assigned to this application"}
+            )
+
+        template_version = (
+            TemplateVersion.objects.filter(template=template)
+            .order_by("-version")
+            .first()
+        )
+        if template_version is None:
+            raise serializers.ValidationError(
+                {"template_id": "Template has no available version"}
+            )
+
+        existing = Evaluation.objects.filter(
+            application_id=application.id,
+            status="in_progress",
+        ).first()
+        if existing:
+            return existing
+
+        return Evaluation.objects.create(
+            subject=application.candidate.user,
+            application=application,
+            position=application.position,
+            template_version=template_version,
+            assigned_to=evaluator,
+            status="in_progress",
+        )

--- a/apps/backend/evaluations/views/evaluation.py
+++ b/apps/backend/evaluations/views/evaluation.py
@@ -1,6 +1,11 @@
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 from evaluations.models.evaluation import Evaluation
-from evaluations.serializers import EvaluationSerializer
+from evaluations.serializers import AssignEvaluationSerializer, EvaluationSerializer
+from users.permissions import IsHrAdminOrDirector
 
 
 class EvaluationViewSet(ModelViewSet):
@@ -12,3 +17,17 @@ class EvaluationViewSet(ModelViewSet):
         .order_by("id")
     )
     serializer_class = EvaluationSerializer
+
+    def get_permissions(self):
+        if self.action == "assign_test":
+            return [IsAuthenticated(), IsHrAdminOrDirector()]
+        return [IsAuthenticated()]
+
+    @action(detail=False, methods=["post"], url_path="assign-test")
+    def assign_test(self, request):
+        serializer = AssignEvaluationSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        evaluation = serializer.save()
+        return Response(
+            EvaluationSerializer(evaluation).data, status=status.HTTP_201_CREATED
+        )

--- a/apps/backend/farid_tests/factories/recruitment.py
+++ b/apps/backend/farid_tests/factories/recruitment.py
@@ -16,9 +16,13 @@ class JobApplicationFactory:
         candidate=None,
         position=None,
         status: str = "applied",
+        assigned_template=None,
     ) -> JobApplication:
         candidate = candidate or CandidateFactory.create()
         position = position or PositionFactory.create()
         return JobApplication.objects.create(
-            candidate=candidate, position=position, status=status
+            candidate=candidate,
+            position=position,
+            status=status,
+            assigned_template=assigned_template,
         )

--- a/apps/backend/farid_tests/factories/users.py
+++ b/apps/backend/farid_tests/factories/users.py
@@ -22,7 +22,6 @@ class UserFactory:
         is_staff: bool = False,
         is_active: bool = True,
     ) -> User:
-
         # ✅ Generate unique email if none provided
         if email is None:
             email = f"user-{uuid.uuid4().hex[:10]}@example.com"

--- a/apps/backend/farid_tests/integrations/test_candidate_crud.py
+++ b/apps/backend/farid_tests/integrations/test_candidate_crud.py
@@ -3,11 +3,21 @@ import pytest
 from django.urls import reverse
 
 from candidates.models import Candidate
-from users.models import User
-from farid_tests.factories import CandidateFactory
-from farid_tests.factories import PositionFactory
+from farid_tests.factories import CandidateFactory, PositionFactory, UserFactory
+from users.models import User, UserRoles
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def hr_api_client(api_client):
+    hr_user = UserFactory.create(
+        email="hr@example.com",
+        password="Secret123",
+        role=UserRoles.HR,
+    )
+    api_client.force_authenticate(user=hr_user)
+    return api_client
 
 
 def test_create_candidate_success(api_client):
@@ -37,6 +47,52 @@ def test_create_candidate_success(api_client):
     assert candidate.user.phone == "0601020304"
     assert candidate.status == "pending"
     assert candidate.flag is False
+
+
+def test_create_candidate_with_password_can_login(api_client):
+    candidate_url = reverse("candidates-list")
+    payload = {
+        "user": {
+            "first_name": "Lina",
+            "last_name": "Candidate",
+            "email": "lina.login@example.com",
+            "phone": "0600000000",
+            "password": "Secret123",
+        }
+    }
+
+    candidate_res = api_client.post(candidate_url, payload, format="json")
+    assert candidate_res.status_code == 201
+
+    login_url = reverse("auth-login")
+    login_res = api_client.post(
+        login_url,
+        {"email": "lina.login@example.com", "password": "Secret123"},
+        format="json",
+    )
+
+    assert login_res.status_code == 200
+    assert "access" in login_res.data
+    assert "refresh" in login_res.data
+
+
+def test_create_candidate_with_weak_password_rejected(api_client):
+    candidate_url = reverse("candidates-list")
+    payload = {
+        "user": {
+            "first_name": "Weak",
+            "last_name": "Password",
+            "email": "weak.password@example.com",
+            "phone": "0600000000",
+            "password": "123",
+        }
+    }
+
+    response = api_client.post(candidate_url, payload, format="json")
+
+    assert response.status_code == 400
+    assert "user" in response.data
+    assert "password" in response.data["user"]
 
 
 def test_create_candidate_missing_user(api_client):
@@ -84,12 +140,12 @@ def test_create_candidate_duplicate_email_rejected(api_client):
     assert "user" in response.data
 
 
-def test_list_candidates(api_client):
+def test_list_candidates(hr_api_client):
     CandidateFactory.create(email="a@example.com")
     CandidateFactory.create(email="b@example.com")
 
     url = reverse("candidates-list")
-    response = api_client.get(url)
+    response = hr_api_client.get(url)
 
     assert response.status_code == 200
     # Supports both list and paginated responses
@@ -101,21 +157,21 @@ def test_list_candidates(api_client):
     assert len(data) >= 2
 
 
-def test_retrieve_candidate(api_client):
+def test_retrieve_candidate(hr_api_client):
     candidate = CandidateFactory.create(email="one@example.com")
 
     url = reverse("candidates-detail", args=[candidate.id])
-    response = api_client.get(url)
+    response = hr_api_client.get(url)
 
     assert response.status_code == 200
     assert response.data["id"] == candidate.id
 
 
-def test_update_candidate_flag(api_client):
+def test_update_candidate_flag(hr_api_client):
     candidate = CandidateFactory.create(email="flag@example.com")
 
     url = reverse("candidates-detail", args=[candidate.id])
-    response = api_client.patch(url, {"flag": True}, format="json")
+    response = hr_api_client.patch(url, {"flag": True}, format="json")
 
     assert response.status_code in (200, 202)  # depending on your viewset config
 
@@ -123,14 +179,117 @@ def test_update_candidate_flag(api_client):
     assert candidate.flag is True
 
 
-def test_update_candidate_target_position(api_client):
+def test_update_candidate_target_position(hr_api_client):
     candidate = CandidateFactory.create(email="tp@example.com")
     pos = PositionFactory.create(title="Forklift Driver")
 
     url = reverse("candidates-detail", args=[candidate.id])
-    response = api_client.patch(url, {"target_position": pos.id}, format="json")
+    response = hr_api_client.patch(url, {"target_position": pos.id}, format="json")
 
     assert response.status_code in (200, 202)
 
     candidate.refresh_from_db()
     assert candidate.target_position_id == pos.id
+
+
+def test_update_candidate_duplicate_email_rejected(hr_api_client):
+    existing = CandidateFactory.create(email="existing@example.com")
+    candidate = CandidateFactory.create(email="to-update@example.com")
+
+    url = reverse("candidates-detail", args=[candidate.id])
+    response = hr_api_client.patch(
+        url,
+        {"user": {"email": existing.user.email}},
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert "user" in response.data
+    assert "email" in response.data["user"]
+
+
+def test_update_candidate_with_weak_password_rejected(hr_api_client):
+    candidate = CandidateFactory.create(email="candidate@example.com")
+
+    url = reverse("candidates-detail", args=[candidate.id])
+    response = hr_api_client.patch(
+        url,
+        {"user": {"password": "123"}},
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert "user" in response.data
+    assert "password" in response.data["user"]
+
+
+def test_update_candidate_is_atomic_when_nested_user_update_fails(hr_api_client):
+    existing = CandidateFactory.create(email="already-used@example.com")
+    candidate = CandidateFactory.create(email="atomic@example.com")
+
+    url = reverse("candidates-detail", args=[candidate.id])
+    response = hr_api_client.patch(
+        url,
+        {
+            "flag": True,
+            "user": {"email": existing.user.email},
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+    candidate.refresh_from_db()
+    assert candidate.flag is False
+
+
+def test_list_candidates_requires_hr_permissions(api_client):
+    CandidateFactory.create(email="a@example.com")
+    url = reverse("candidates-list")
+
+    response = api_client.get(url)
+
+    assert response.status_code in (401, 403)
+
+
+def test_list_candidates_denied_for_authenticated_non_hr_user(api_client):
+    employee_user = UserFactory.create(
+        email="employee@example.com",
+        password="Secret123",
+        role=UserRoles.EMPLOYEE,
+    )
+    api_client.force_authenticate(user=employee_user)
+    url = reverse("candidates-list")
+
+    response = api_client.get(url)
+
+    assert response.status_code == 403
+
+
+def test_retrieve_candidate_denied_for_authenticated_non_hr_user(api_client):
+    candidate = CandidateFactory.create(email="restricted@example.com")
+    employee_user = UserFactory.create(
+        email="employee-retrieve@example.com",
+        password="Secret123",
+        role=UserRoles.EMPLOYEE,
+    )
+    api_client.force_authenticate(user=employee_user)
+    url = reverse("candidates-detail", args=[candidate.id])
+
+    response = api_client.get(url)
+
+    assert response.status_code == 403
+
+
+def test_update_candidate_denied_for_authenticated_non_hr_user(api_client):
+    candidate = CandidateFactory.create(email="restricted-update@example.com")
+    employee_user = UserFactory.create(
+        email="employee-update@example.com",
+        password="Secret123",
+        role=UserRoles.EMPLOYEE,
+    )
+    api_client.force_authenticate(user=employee_user)
+    url = reverse("candidates-detail", args=[candidate.id])
+
+    response = api_client.patch(url, {"flag": True}, format="json")
+
+    assert response.status_code == 403

--- a/apps/backend/farid_tests/integrations/test_evaluation_crud.py
+++ b/apps/backend/farid_tests/integrations/test_evaluation_crud.py
@@ -5,7 +5,9 @@ from django.urls import reverse
 from evaluations.models.evaluation import Evaluation
 from farid_tests.factories.users import UserFactory
 from farid_tests.factories.positions import PositionFactory
+from farid_tests.factories.recruitment import JobApplicationFactory
 from farid_tests.factories.templates_grid import TemplateFactory, TemplateVersionFactory
+from users.models import UserRoles
 
 pytestmark = pytest.mark.django_db
 
@@ -16,7 +18,18 @@ def _unwrap_list_response(data):
     return data["results"] if isinstance(data, dict) and "results" in data else data
 
 
-def test_create_evaluation_success(api_client):
+@pytest.fixture
+def hr_api_client(api_client):
+    hr_user = UserFactory.create(
+        email="hr-evaluations@example.com",
+        password="Secret123",
+        role=UserRoles.HR,
+    )
+    api_client.force_authenticate(user=hr_user)
+    return api_client
+
+
+def test_create_evaluation_success(hr_api_client):
     subject = UserFactory.create(email="cand@example.com", password=None)
     template = TemplateFactory.create(name="Driver Template")
     template_version = TemplateVersionFactory.create(template=template, version=1)
@@ -32,7 +45,7 @@ def test_create_evaluation_success(api_client):
     }
 
     url = reverse(f"{BASENAME}-list")
-    res = api_client.post(url, payload, format="json")
+    res = hr_api_client.post(url, payload, format="json")
 
     assert res.status_code == 201
     assert "id" in res.data
@@ -44,9 +57,9 @@ def test_create_evaluation_success(api_client):
     assert ev.status == "in_progress"
 
 
-def test_create_evaluation_missing_fields(api_client):
+def test_create_evaluation_missing_fields(hr_api_client):
     url = reverse(f"{BASENAME}-list")
-    res = api_client.post(url, {}, format="json")
+    res = hr_api_client.post(url, {}, format="json")
 
     assert res.status_code == 400
     # minimally required:
@@ -54,7 +67,7 @@ def test_create_evaluation_missing_fields(api_client):
     assert "template_version" in res.data
 
 
-def test_list_evaluations(api_client):
+def test_list_evaluations(hr_api_client):
     # Create 2 evals via ORM (independent of API create)
     subject = UserFactory.create(email="s1@example.com", password=None)
     template_version = TemplateVersionFactory.create(
@@ -69,14 +82,14 @@ def test_list_evaluations(api_client):
     )
 
     url = reverse(f"{BASENAME}-list")
-    res = api_client.get(url)
+    res = hr_api_client.get(url)
 
     assert res.status_code == 200
     items = _unwrap_list_response(res.data)
     assert len(items) >= 2
 
 
-def test_retrieve_evaluation(api_client):
+def test_retrieve_evaluation(hr_api_client):
     subject = UserFactory.create(email="s2@example.com", password=None)
     template_version = TemplateVersionFactory.create(
         template=TemplateFactory.create(), version=1
@@ -86,13 +99,13 @@ def test_retrieve_evaluation(api_client):
     )
 
     url = reverse(f"{BASENAME}-detail", args=[ev.id])
-    res = api_client.get(url)
+    res = hr_api_client.get(url)
 
     assert res.status_code == 200
     assert res.data["id"] == ev.id
 
 
-def test_update_evaluation_status(api_client):
+def test_update_evaluation_status(hr_api_client):
     subject = UserFactory.create(email="s3@example.com", password=None)
     template_version = TemplateVersionFactory.create(
         template=TemplateFactory.create(), version=1
@@ -102,9 +115,54 @@ def test_update_evaluation_status(api_client):
     )
 
     url = reverse(f"{BASENAME}-detail", args=[ev.id])
-    res = api_client.patch(url, {"status": "completed"}, format="json")
+    res = hr_api_client.patch(url, {"status": "completed"}, format="json")
 
     assert res.status_code in (200, 202)
 
     ev.refresh_from_db()
     assert ev.status == "completed"
+
+
+def test_assign_test_creates_evaluation_from_application(hr_api_client):
+    template = TemplateFactory.create(name="Driver Template")
+    template_version = TemplateVersionFactory.create(template=template, version=1)
+    manager = UserFactory.create(
+        email="manager@example.com",
+        password="Secret123",
+        role=UserRoles.MANAGER,
+    )
+    application = JobApplicationFactory.create(assigned_template=template)
+    url = reverse(f"{BASENAME}-assign-test")
+    res = hr_api_client.post(
+        url,
+        {"application_id": application.id, "evaluator_id": manager.id},
+        format="json",
+    )
+
+    assert res.status_code == 201
+    assert res.data["application"] == application.id
+    assert res.data["assigned_to"] == manager.id
+    assert res.data["subject"] == application.candidate.user_id
+    assert res.data["position"] == application.position_id
+    assert res.data["template_version"] == template_version.id
+
+
+def test_assign_test_requires_manager_as_evaluator(hr_api_client):
+    template = TemplateFactory.create(name="Driver Template")
+    TemplateVersionFactory.create(template=template, version=1)
+    non_manager = UserFactory.create(
+        email="employee@example.com",
+        password="Secret123",
+        role=UserRoles.EMPLOYEE,
+    )
+    application = JobApplicationFactory.create(assigned_template=template)
+
+    url = reverse(f"{BASENAME}-assign-test")
+    res = hr_api_client.post(
+        url,
+        {"application_id": application.id, "evaluator_id": non_manager.id},
+        format="json",
+    )
+
+    assert res.status_code == 400
+    assert "evaluator_id" in res.data

--- a/apps/backend/farid_tests/integrations/test_job_application_crud.py
+++ b/apps/backend/farid_tests/integrations/test_job_application_crud.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 from farid_tests.factories.candidates import CandidateFactory
 from farid_tests.factories.positions import PositionFactory
+from farid_tests.factories.templates_grid import TemplateFactory
 from recruitment.models.job_application import JobApplication
 
 pytestmark = pytest.mark.django_db
@@ -89,3 +90,19 @@ def test_update_job_application_status(api_client):
 
     app.refresh_from_db()
     assert app.status == "in_review"
+
+
+def test_assign_template_to_job_application(api_client):
+    app = JobApplication.objects.create(
+        candidate=CandidateFactory.create(),
+        position=PositionFactory.create(),
+    )
+    template = TemplateFactory.create(name="Driver Safety Test")
+
+    url = reverse(f"{BASENAME}-detail", args=[app.id])
+    res = api_client.patch(url, {"assigned_template": template.id}, format="json")
+
+    assert res.status_code in (200, 202)
+
+    app.refresh_from_db()
+    assert app.assigned_template_id == template.id

--- a/apps/backend/positions/serializers/__init__.py
+++ b/apps/backend/positions/serializers/__init__.py
@@ -1,4 +1,4 @@
 from .position import PositionSerializer as PositionSerializer
-from .position import PublicPositionSerializer as PublicPositionSerializer 
+from .position import PublicPositionSerializer as PublicPositionSerializer
 
-__all__ = ["PositionSerializer"]
+__all__ = ["PositionSerializer", "PublicPositionSerializer"]

--- a/apps/backend/positions/serializers/position.py
+++ b/apps/backend/positions/serializers/position.py
@@ -20,6 +20,7 @@ class PositionSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_at", "updated_at"]
 
+
 class PublicPositionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Position

--- a/apps/backend/positions/views/__init__.py
+++ b/apps/backend/positions/views/__init__.py
@@ -1,3 +1,4 @@
 from .position import PositionViewSet as PositionViewSet
 from .position import PublicPositionViewSet as PublicPositionViewSet
-__all__ = ["PositionViewSet"]
+
+__all__ = ["PositionViewSet", "PublicPositionViewSet"]

--- a/apps/backend/positions/views/position.py
+++ b/apps/backend/positions/views/position.py
@@ -1,10 +1,9 @@
-from rest_framework.viewsets import ModelViewSet
 from positions.models import Position
 from positions.serializers import PositionSerializer, PublicPositionSerializer
-from rest_framework.permissions import AllowAny, IsAuthenticated
-from users.permissions import IsHrAdminOrDirector
 from rest_framework.permissions import AllowAny
-from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
+from users.permissions import IsHrAdminOrDirector
 
 
 class PositionViewSet(ModelViewSet):
@@ -20,18 +19,16 @@ class PositionViewSet(ModelViewSet):
 
         return [IsAuthenticated()]
 
+
 class PublicPositionViewSet(ReadOnlyModelViewSet):
     permission_classes = [AllowAny]
 
     def get_queryset(self):
         return (
-            Position.objects
-            .filter(is_active=True)
+            Position.objects.filter(is_active=True)
             .select_related("company")
             .order_by("-created_at")
         )
 
     def get_serializer_class(self):
-        if self.action == "retrieve":
-            return PublicPositionSerializer
         return PublicPositionSerializer

--- a/apps/backend/recruitment/migrations/0002_jobapplication_assigned_template.py
+++ b/apps/backend/recruitment/migrations/0002_jobapplication_assigned_template.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("templates_grid", "0001_initial"),
+        ("recruitment", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="jobapplication",
+            name="assigned_template",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="job_applications",
+                to="templates_grid.template",
+            ),
+        ),
+    ]

--- a/apps/backend/recruitment/models/job_application.py
+++ b/apps/backend/recruitment/models/job_application.py
@@ -17,6 +17,13 @@ class JobApplication(models.Model):
     position = models.ForeignKey(
         "positions.Position", on_delete=models.PROTECT, related_name="applications"
     )
+    assigned_template = models.ForeignKey(
+        "templates_grid.Template",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="job_applications",
+    )
 
     status = models.CharField(
         max_length=20,

--- a/apps/backend/recruitment/serializers/job_application.py
+++ b/apps/backend/recruitment/serializers/job_application.py
@@ -7,7 +7,15 @@ from recruitment.models.job_application import JobApplication
 class JobApplicationSerializer(serializers.ModelSerializer):
     class Meta:
         model = JobApplication
-        fields = ["id", "candidate", "position", "status", "created_at", "updated_at"]
+        fields = [
+            "id",
+            "candidate",
+            "position",
+            "status",
+            "assigned_template",
+            "created_at",
+            "updated_at",
+        ]
         read_only_fields = ["id", "created_at", "updated_at"]
         validators = [
             UniqueTogetherValidator(

--- a/apps/candidate/src/app/app.config.ts
+++ b/apps/candidate/src/app/app.config.ts
@@ -1,6 +1,12 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import {
+  ApplicationConfig,
+  provideBrowserGlobalErrorListeners,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+
+import { authInterceptor } from '@core/auth/interceptors/auth.interceptor';
 
 import { appRoutes } from './app.routes';
 
@@ -9,6 +15,6 @@ export const appConfig: ApplicationConfig = {
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes),
-    provideHttpClient(),
-  ]
+    provideHttpClient(withInterceptors([authInterceptor])),
+  ],
 };

--- a/apps/candidate/src/app/app.html
+++ b/apps/candidate/src/app/app.html
@@ -1,1 +1,89 @@
-<router-outlet />
+<section class="min-h-screen bg-slate-950 text-slate-100">
+  <header
+    class="sticky top-0 z-40 flex h-[72px] items-center justify-between border-b border-slate-800 bg-gradient-to-r from-slate-900 via-slate-900 to-slate-800 px-6"
+  >
+    <div class="flex items-center gap-3">
+      <div
+        class="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-600/90 shadow-md shadow-blue-600/20"
+        aria-hidden="true"
+      >
+        <span class="text-lg text-white">💼</span>
+      </div>
+
+      <div class="leading-tight">
+        <p class="text-sm font-semibold text-white sm:text-base">{{ appTitle }}</p>
+        <p class="text-xs text-slate-400">Candidate portal</p>
+      </div>
+    </div>
+
+    <button
+      type="button"
+      class="flex items-center gap-2 rounded-xl border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-slate-100 transition hover:border-slate-600 hover:bg-slate-800"
+      data-testid="profile-button"
+      (click)="onProfileClicked()"
+    >
+      <span
+        class="flex h-8 w-8 items-center justify-center rounded-full border border-slate-600 bg-slate-700 text-xs font-semibold"
+      >
+        {{ profileInitials }}
+      </span>
+      <span class="hidden sm:inline">{{ profileFullName }}</span>
+    </button>
+  </header>
+
+  <router-outlet />
+
+  @if (authModalOpen) {
+    <app-auth-modal
+      (authenticated)="onAuthSuccess()"
+      (closed)="authModalOpen = false"
+    />
+  }
+
+  <app-ui-modal
+    [open]="profileModalOpen"
+    (openChange)="profileModalOpen = $event"
+    title="My profile"
+    size="md"
+  >
+    <form class="space-y-4" [formGroup]="profileForm" (ngSubmit)="onProfileSave()">
+      <app-ui-text-input
+        formControlName="firstName"
+        label="First name"
+        placeholder="John"
+      />
+
+      <app-ui-text-input
+        formControlName="lastName"
+        label="Last name"
+        placeholder="Doe"
+      />
+
+      <app-ui-text-input
+        formControlName="email"
+        label="Email"
+        placeholder="candidate@example.com"
+        type="email"
+      />
+
+      <app-ui-text-input
+        formControlName="phone"
+        label="Phone"
+        placeholder="+33..."
+        type="tel"
+      />
+
+      <div modal-actions class="flex w-full items-center justify-between gap-2">
+        <button
+          type="button"
+          class="rounded-xl border border-slate-700 px-4 py-2 text-sm text-slate-200 hover:bg-slate-800"
+          (click)="onLogoutClicked()"
+        >
+          Log out
+        </button>
+
+        <app-ui-button-primary type="submit" label="Save profile" />
+      </div>
+    </form>
+  </app-ui-modal>
+</section>

--- a/apps/candidate/src/app/app.spec.ts
+++ b/apps/candidate/src/app/app.spec.ts
@@ -1,10 +1,43 @@
 import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import {
+  AuthService,
+  AuthenticatedCandidate,
+} from '@core/auth/services/auth.service';
+
 import { App } from './app';
 
 describe('App', () => {
+  const authenticatedCandidate: AuthenticatedCandidate = {
+    candidateId: 7,
+    firstName: 'Farid',
+    lastName: 'Candidate',
+    email: 'farid@example.com',
+    phone: '+3311111111',
+  };
+
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+
   beforeEach(async () => {
+    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', [
+      'isAuthenticated',
+      'getAuthenticatedCandidate',
+      'saveAuthenticatedCandidate',
+      'logout',
+    ]);
+
+    authServiceSpy.isAuthenticated.and.returnValue(false);
+    authServiceSpy.getAuthenticatedCandidate.and.returnValue(null);
+
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: authServiceSpy,
+        },
+      ],
     }).compileComponents();
   });
 
@@ -12,5 +45,87 @@ describe('App', () => {
     const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
+  });
+
+  it('renders the candidate top bar title', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Farid Candidate');
+  });
+
+  it('opens auth modal from profile button when user is logged out', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const profileButton = fixture.debugElement.query(
+      By.css('[data-testid="profile-button"]'),
+    ).nativeElement as HTMLButtonElement;
+
+    profileButton.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.authModalOpen).toBeTrue();
+    expect(fixture.componentInstance.profileModalOpen).toBeFalse();
+  });
+
+  it('opens profile modal with prefilled values when user is authenticated', () => {
+    authServiceSpy.isAuthenticated.and.returnValue(true);
+    authServiceSpy.getAuthenticatedCandidate.and.returnValue(authenticatedCandidate);
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const profileButton = fixture.debugElement.query(
+      By.css('[data-testid="profile-button"]'),
+    ).nativeElement as HTMLButtonElement;
+
+    profileButton.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.profileModalOpen).toBeTrue();
+    expect(fixture.componentInstance.profileForm.getRawValue()).toEqual({
+      firstName: 'Farid',
+      lastName: 'Candidate',
+      email: 'farid@example.com',
+      phone: '+3311111111',
+    });
+  });
+
+  it('saves profile changes for authenticated user', () => {
+    authServiceSpy.getAuthenticatedCandidate.and.returnValue(authenticatedCandidate);
+
+    const fixture = TestBed.createComponent(App);
+    const component = fixture.componentInstance;
+    component.profileModalOpen = true;
+
+    component.profileForm.patchValue({
+      firstName: 'Farid',
+      lastName: 'Updated',
+      email: 'updated@example.com',
+      phone: '+3399999999',
+    });
+
+    component.onProfileSave();
+
+    expect(authServiceSpy.saveAuthenticatedCandidate).toHaveBeenCalledWith({
+      candidateId: 7,
+      firstName: 'Farid',
+      lastName: 'Updated',
+      email: 'updated@example.com',
+      phone: '+3399999999',
+    });
+    expect(component.profileModalOpen).toBeFalse();
+  });
+
+  it('logs out and closes profile modal', () => {
+    const fixture = TestBed.createComponent(App);
+    const component = fixture.componentInstance;
+    component.profileModalOpen = true;
+
+    component.onLogoutClicked();
+
+    expect(authServiceSpy.logout).toHaveBeenCalledTimes(1);
+    expect(component.profileModalOpen).toBeFalse();
   });
 });

--- a/apps/candidate/src/app/app.ts
+++ b/apps/candidate/src/app/app.ts
@@ -1,12 +1,128 @@
-import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterOutlet } from '@angular/router';
+
+import { AuthModalComponent } from '@core/auth/components/auth-modal/auth-modal.component';
+import {
+  AuthService,
+  AuthenticatedCandidate,
+} from '@core/auth/services/auth.service';
+import { UiButtonPrimaryComponent } from '@lib-ui/button-primary/button-primary.component';
+import { UiModalComponent } from '@lib-ui/modal/modal.component';
+import { UiTextInputComponent } from '@lib-ui/text-input/text-input.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterOutlet,
+    AuthModalComponent,
+    UiModalComponent,
+    UiButtonPrimaryComponent,
+    UiTextInputComponent,
+  ],
   templateUrl: './app.html',
 })
 export class App {
-  protected readonly title = signal('candidate');
+  private readonly authService = inject(AuthService);
+  private readonly formBuilder = inject(FormBuilder);
+
+  readonly appTitle = 'Farid Candidate';
+
+  authModalOpen = false;
+  profileModalOpen = false;
+
+  readonly profileForm = this.formBuilder.nonNullable.group({
+    firstName: ['', [Validators.required]],
+    lastName: ['', [Validators.required]],
+    email: ['', [Validators.required, Validators.email]],
+    phone: [''],
+  });
+
+  onProfileClicked(): void {
+    if (!this.authService.isAuthenticated()) {
+      this.authModalOpen = true;
+      return;
+    }
+
+    this.openProfileModal();
+  }
+
+  onAuthSuccess(): void {
+    this.authModalOpen = false;
+    this.openProfileModal();
+  }
+
+  onProfileSave(): void {
+    this.profileForm.markAllAsTouched();
+    if (this.profileForm.invalid) {
+      return;
+    }
+
+    const currentCandidate = this.authService.getAuthenticatedCandidate();
+    if (!currentCandidate) {
+      this.authModalOpen = true;
+      this.profileModalOpen = false;
+      return;
+    }
+
+    const formValue = this.profileForm.getRawValue();
+
+    this.authService.saveAuthenticatedCandidate({
+      candidateId: currentCandidate.candidateId,
+      firstName: formValue.firstName,
+      lastName: formValue.lastName,
+      email: formValue.email,
+      phone: formValue.phone,
+    });
+
+    this.profileModalOpen = false;
+  }
+
+  onLogoutClicked(): void {
+    this.authService.logout();
+    this.profileModalOpen = false;
+  }
+
+  get profileInitials(): string {
+    const candidate = this.authService.getAuthenticatedCandidate();
+    if (!candidate) {
+      return '👤';
+    }
+
+    return `${candidate.firstName.charAt(0)}${candidate.lastName.charAt(0)}`.toUpperCase();
+  }
+
+  get profileFullName(): string {
+    const candidate = this.authService.getAuthenticatedCandidate();
+    if (!candidate) {
+      return 'Guest';
+    }
+
+    return `${candidate.firstName} ${candidate.lastName}`.trim();
+  }
+
+  private openProfileModal(): void {
+    const candidate = this.authService.getAuthenticatedCandidate();
+    if (!candidate) {
+      this.authModalOpen = true;
+      this.profileModalOpen = false;
+      return;
+    }
+
+    this.patchProfileForm(candidate);
+    this.profileModalOpen = true;
+  }
+
+  private patchProfileForm(candidate: AuthenticatedCandidate): void {
+    this.profileForm.patchValue({
+      firstName: candidate.firstName,
+      lastName: candidate.lastName,
+      email: candidate.email,
+      phone: candidate.phone,
+    });
+  }
 }

--- a/apps/candidate/src/app/core/auth/components/auth-modal/auth-modal.component.html
+++ b/apps/candidate/src/app/core/auth/components/auth-modal/auth-modal.component.html
@@ -1,34 +1,70 @@
-<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
+<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
   <div class="w-full max-w-md">
-
     <app-auth-card
       [title]="mode === 'signin' ? 'Sign in' : 'Create account'"
       subtitle="Access your candidate space"
     >
+      @if (errorMessage) {
+        <app-ui-alert [message]="errorMessage" variant="error" />
+      }
 
-      <!-- FORM PLACEHOLDER -->
-      <div class="space-y-4">
+      <form class="space-y-4" [formGroup]="authForm" (ngSubmit)="onSubmit()">
+        @if (mode === 'signup') {
+          <app-ui-text-input
+            formControlName="firstName"
+            label="First name"
+            placeholder="John"
+            [error]="getFieldError('firstName')"
+          />
 
-        <input class="w-full rounded-xl bg-slate-900 border border-slate-800 p-3"
-               placeholder="Email" />
+          <app-ui-text-input
+            formControlName="lastName"
+            label="Last name"
+            placeholder="Doe"
+            [error]="getFieldError('lastName')"
+          />
 
-        <input class="w-full rounded-xl bg-slate-900 border border-slate-800 p-3"
-               placeholder="Password"
-               type="password" />
+          <app-ui-text-input
+            formControlName="phone"
+            label="Phone"
+            placeholder="+33..."
+            type="tel"
+            [error]="getFieldError('phone')"
+          />
+        }
 
-        <app-ui-button-primary (click)="onAuthSuccess()">
-          {{ mode === 'signin' ? 'Sign in' : 'Create account' }}
-        </app-ui-button-primary>
+        <app-ui-text-input
+          formControlName="email"
+          label="Email"
+          placeholder="candidate@example.com"
+          type="email"
+          [error]="getFieldError('email')"
+        />
 
-        <button class="text-sm text-slate-400" (click)="switchMode()">
-          {{ mode === 'signin'
-            ? 'No account? Sign up'
-            : 'Already have an account? Sign in' }}
+        <app-ui-text-input
+          formControlName="password"
+          label="Password"
+          placeholder="••••••••"
+          type="password"
+          [error]="getFieldError('password')"
+        />
+
+        <app-ui-button-primary
+          type="submit"
+          [loading]="isSubmitting"
+          [label]="mode === 'signin' ? 'Sign in' : 'Create account'"
+        />
+      </form>
+
+      <div class="mt-3 flex items-center justify-between text-sm">
+        <button class="text-slate-400 hover:text-slate-200" type="button" (click)="switchMode()">
+          {{ mode === 'signin' ? 'No account? Sign up' : 'Already have an account? Sign in' }}
         </button>
 
+        <button class="text-slate-500 hover:text-slate-300" type="button" (click)="onClose()">
+          Close
+        </button>
       </div>
-
     </app-auth-card>
-
   </div>
 </div>

--- a/apps/candidate/src/app/core/auth/components/auth-modal/auth-modal.component.spec.ts
+++ b/apps/candidate/src/app/core/auth/components/auth-modal/auth-modal.component.spec.ts
@@ -1,0 +1,111 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { AuthService } from '@core/auth/services/auth.service';
+
+import { AuthModalComponent } from './auth-modal.component';
+
+describe('AuthModalComponent', () => {
+  let fixture: ComponentFixture<AuthModalComponent>;
+  let component: AuthModalComponent;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+
+  beforeEach(async () => {
+    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', [
+      'signIn',
+      'signUp',
+    ]);
+
+    authServiceSpy.signIn.and.returnValue(
+      of({
+        candidateId: 1,
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        phone: '',
+      }),
+    );
+    authServiceSpy.signUp.and.returnValue(
+      of({
+        candidateId: 1,
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        phone: '',
+      }),
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [AuthModalComponent],
+      providers: [{ provide: AuthService, useValue: authServiceSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AuthModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('signs in and emits authenticated on success', () => {
+    spyOn(component.authenticated, 'emit');
+
+    component.authForm.patchValue({
+      email: 'john@example.com',
+      password: 'Secret123',
+    });
+
+    component.onSubmit();
+
+    expect(authServiceSpy.signIn).toHaveBeenCalled();
+    expect(component.authenticated.emit).toHaveBeenCalledTimes(1);
+    expect(component.errorMessage).toBeNull();
+  });
+
+  it('shows backend error when sign in fails', () => {
+    authServiceSpy.signIn.and.returnValue(throwError(() => 'Invalid credentials.'));
+
+    component.authForm.patchValue({
+      email: 'john@example.com',
+      password: 'Secret123',
+    });
+
+    component.onSubmit();
+
+    expect(component.errorMessage).toBe('Invalid credentials.');
+  });
+
+
+
+  it('shows required field errors in signup mode', () => {
+    component.switchMode();
+
+    component.authForm.patchValue({
+      firstName: '',
+      lastName: '',
+      phone: '',
+      email: 'invalid-email',
+      password: '123',
+    });
+
+    component.onSubmit();
+
+    expect(component.getFieldError('firstName')).toBe('This field is required.');
+    expect(component.getFieldError('email')).toBe('Please enter a valid email address.');
+    expect(component.getFieldError('password')).toContain('Minimum 8 characters');
+    expect(authServiceSpy.signUp).not.toHaveBeenCalled();
+  });
+
+  it('calls signUp in signup mode', () => {
+    component.switchMode();
+    component.authForm.patchValue({
+      firstName: 'Jane',
+      lastName: 'Smith',
+      phone: '+33123456',
+      email: 'jane@example.com',
+      password: 'Secret123',
+    });
+
+    component.onSubmit();
+
+    expect(authServiceSpy.signUp).toHaveBeenCalled();
+  });
+});

--- a/apps/candidate/src/app/core/auth/components/auth-modal/auth-modal.component.ts
+++ b/apps/candidate/src/app/core/auth/components/auth-modal/auth-modal.component.ts
@@ -1,29 +1,137 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Output, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { finalize } from 'rxjs';
+
+import { AuthService } from '@core/auth/services/auth.service';
+import { UiAlertComponent } from '@lib-ui/alert/alert.component';
 import { AuthCardComponent } from '@lib-ui/auth-card/auth-card.component';
 import { UiButtonPrimaryComponent } from '@lib-ui/button-primary/button-primary.component';
-import { CommonModule } from "@angular/common";
-import { Component, EventEmitter, Output } from "@angular/core";
+import { UiTextInputComponent } from '@lib-ui/text-input/text-input.component';
 
 @Component({
   selector: 'app-auth-modal',
   standalone: true,
-  imports: [CommonModule, AuthCardComponent, UiButtonPrimaryComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    AuthCardComponent,
+    UiButtonPrimaryComponent,
+    UiTextInputComponent,
+    UiAlertComponent,
+  ],
   templateUrl: './auth-modal.component.html',
 })
 export class AuthModalComponent {
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+
   @Output() authenticated = new EventEmitter<void>();
   @Output() closed = new EventEmitter<void>();
 
   mode: 'signin' | 'signup' = 'signin';
+  isSubmitting = false;
+  errorMessage: string | null = null;
+
+  readonly authForm = this.formBuilder.nonNullable.group({
+    firstName: [''],
+    lastName: [''],
+    phone: [''],
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(8)]],
+  });
+
+  constructor() {
+    this.applyModeValidators();
+  }
 
   switchMode(): void {
     this.mode = this.mode === 'signin' ? 'signup' : 'signin';
+    this.errorMessage = null;
+    this.authForm.patchValue({ password: '' });
+    this.applyModeValidators();
   }
 
-  onAuthSuccess(): void {
-    this.authenticated.emit();
+  onSubmit(): void {
+    this.authForm.markAllAsTouched();
+    if (this.authForm.invalid || this.isSubmitting) {
+      return;
+    }
+
+    const formValue = this.authForm.getRawValue();
+    this.errorMessage = null;
+    this.isSubmitting = true;
+
+    const authRequest =
+      this.mode === 'signin'
+        ? this.authService.signIn({
+            email: formValue.email,
+            password: formValue.password,
+          })
+        : this.authService.signUp({
+            firstName: formValue.firstName,
+            lastName: formValue.lastName,
+            phone: formValue.phone,
+            email: formValue.email,
+            password: formValue.password,
+          });
+
+    authRequest
+      .pipe(finalize(() => (this.isSubmitting = false)))
+      .subscribe({
+        next: () => {
+          this.authenticated.emit();
+        },
+        error: (errorMessage: string) => {
+          this.errorMessage = errorMessage;
+        },
+      });
   }
 
   onClose(): void {
     this.closed.emit();
+  }
+
+  getFieldError(controlName: 'firstName' | 'lastName' | 'phone' | 'email' | 'password'): string | null {
+    const control = this.authForm.controls[controlName];
+
+    if (!control.touched || !control.errors) {
+      return null;
+    }
+
+    if (control.errors['required']) {
+      return 'This field is required.';
+    }
+
+    if (control.errors['email']) {
+      return 'Please enter a valid email address.';
+    }
+
+    if (control.errors['minlength']) {
+      const minimumLength = control.errors['minlength'].requiredLength as number;
+      return `Minimum ${minimumLength} characters.`;
+    }
+
+    return null;
+  }
+
+  private applyModeValidators(): void {
+    const firstNameControl = this.authForm.controls.firstName;
+    const lastNameControl = this.authForm.controls.lastName;
+    const phoneControl = this.authForm.controls.phone;
+
+    if (this.mode === 'signup') {
+      firstNameControl.setValidators([Validators.required]);
+      lastNameControl.setValidators([Validators.required]);
+      phoneControl.setValidators([Validators.required]);
+    } else {
+      firstNameControl.clearValidators();
+      lastNameControl.clearValidators();
+      phoneControl.clearValidators();
+    }
+
+    firstNameControl.updateValueAndValidity({ emitEvent: false });
+    lastNameControl.updateValueAndValidity({ emitEvent: false });
+    phoneControl.updateValueAndValidity({ emitEvent: false });
   }
 }

--- a/apps/candidate/src/app/core/auth/interceptors/auth.interceptor.spec.ts
+++ b/apps/candidate/src/app/core/auth/interceptors/auth.interceptor.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+
+import { AuthService } from '@core/auth/services/auth.service';
+import { TokenStorageService } from '@core/auth/services/token-storage.service';
+
+import { authInterceptor } from './auth.interceptor';
+
+describe('authInterceptor (candidate)', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let tokenStorageSpy: jasmine.SpyObj<TokenStorageService>;
+
+  beforeEach(() => {
+    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', ['refresh']);
+    tokenStorageSpy = jasmine.createSpyObj<TokenStorageService>('TokenStorageService', [
+      'getAccessToken',
+      'getRefreshToken',
+      'saveTokens',
+      'clear',
+    ]);
+
+    tokenStorageSpy.getAccessToken.and.returnValue('ACCESS');
+    tokenStorageSpy.getRefreshToken.and.returnValue('REFRESH');
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: TokenStorageService, useValue: tokenStorageSpy },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('adds authorization header on non-auth requests', () => {
+    http.get('/api/public/positions').subscribe();
+
+    const request = httpMock.expectOne('/api/public/positions');
+
+    expect(request.request.headers.get('Authorization')).toBe('Bearer ACCESS');
+    request.flush([]);
+  });
+
+  it('refreshes token and retries request after 401', () => {
+    authServiceSpy.refresh.and.returnValue(of({ access: 'NEW_ACCESS', refresh: 'NEW_REFRESH' }));
+
+    http.get('/api/public/positions').subscribe();
+
+    const firstRequest = httpMock.expectOne('/api/public/positions');
+    firstRequest.flush({ detail: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    const retriedRequest = httpMock.expectOne('/api/public/positions');
+    expect(retriedRequest.request.headers.get('Authorization')).toBe('Bearer NEW_ACCESS');
+    retriedRequest.flush([]);
+
+    expect(authServiceSpy.refresh).toHaveBeenCalledOnceWith('REFRESH');
+    expect(tokenStorageSpy.saveTokens).toHaveBeenCalledWith('NEW_ACCESS', 'NEW_REFRESH');
+  });
+
+  it('clears tokens if refresh fails', () => {
+    authServiceSpy.refresh.and.returnValue(throwError(() => new Error('refresh failed')));
+
+    http.get('/api/public/positions').subscribe({ error: () => void 0 });
+
+    const firstRequest = httpMock.expectOne('/api/public/positions');
+    firstRequest.flush({ detail: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    expect(tokenStorageSpy.clear).toHaveBeenCalled();
+  });
+});

--- a/apps/candidate/src/app/core/auth/interceptors/auth.interceptor.ts
+++ b/apps/candidate/src/app/core/auth/interceptors/auth.interceptor.ts
@@ -1,0 +1,72 @@
+import { inject } from '@angular/core';
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandlerFn,
+  HttpInterceptorFn,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable, catchError, switchMap, throwError } from 'rxjs';
+
+import { AuthService } from '@core/auth/services/auth.service';
+import { TokenStorageService } from '@core/auth/services/token-storage.service';
+
+export const authInterceptor: HttpInterceptorFn = (
+  request: HttpRequest<unknown>,
+  next: HttpHandlerFn,
+): Observable<HttpEvent<unknown>> => {
+  const tokenStorage = inject(TokenStorageService);
+  const authService = inject(AuthService);
+
+  const isAuthRequest =
+    request.url.includes('/api/auth/login') ||
+    request.url.includes('/api/auth/refresh') ||
+    request.url.includes('/api/candidates/');
+
+  const accessToken = tokenStorage.getAccessToken();
+
+  const authenticatedRequest =
+    !isAuthRequest && accessToken
+      ? request.clone({
+          setHeaders: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+      : request;
+
+  return next(authenticatedRequest).pipe(
+    catchError((error: unknown) => {
+      if (!(error instanceof HttpErrorResponse)) {
+        return throwError(() => error);
+      }
+
+      if (error.status !== 401 || isAuthRequest) {
+        return throwError(() => error);
+      }
+
+      const refreshToken = tokenStorage.getRefreshToken();
+      if (!refreshToken) {
+        tokenStorage.clear();
+        return throwError(() => error);
+      }
+
+      return authService.refresh(refreshToken).pipe(
+        switchMap((response) => {
+          tokenStorage.saveTokens(response.access, response.refresh ?? refreshToken);
+
+          const retriedRequest = request.clone({
+            setHeaders: {
+              Authorization: `Bearer ${response.access}`,
+            },
+          });
+
+          return next(retriedRequest);
+        }),
+        catchError((refreshError: unknown) => {
+          tokenStorage.clear();
+          return throwError(() => refreshError);
+        }),
+      );
+    }),
+  );
+};

--- a/apps/candidate/src/app/core/auth/services/auth.service.spec.ts
+++ b/apps/candidate/src/app/core/auth/services/auth.service.spec.ts
@@ -1,0 +1,137 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { environment } from '@env/environment';
+
+import { TokenStorageService } from '@core/auth/services/token-storage.service';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService (candidate)', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+  let tokenStorageSpy: jasmine.SpyObj<TokenStorageService>;
+
+  const loginUrl = `${environment.apiBaseUrl}/api/auth/login/`;
+  const refreshUrl = `${environment.apiBaseUrl}/api/auth/refresh/`;
+  const candidatesUrl = `${environment.apiBaseUrl}/api/candidates/`;
+
+  beforeEach(() => {
+    localStorage.clear();
+
+    tokenStorageSpy = jasmine.createSpyObj<TokenStorageService>('TokenStorageService', [
+      'saveTokens',
+      'clear',
+      'isAuthenticated',
+    ]);
+    tokenStorageSpy.isAuthenticated.and.returnValue(false);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: TokenStorageService, useValue: tokenStorageSpy },
+      ],
+    });
+
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('signIn stores tokens and resolves candidate profile from candidates API', () => {
+    let candidateId: number | null = null;
+
+    service
+      .signIn({ email: 'john@example.com', password: 'Secret123' })
+      .subscribe((candidate) => {
+        candidateId = candidate.candidateId;
+      });
+
+    const loginRequest = httpMock.expectOne(loginUrl);
+    expect(loginRequest.request.method).toBe('POST');
+    loginRequest.flush({
+      access: 'access-token',
+      refresh: 'refresh-token',
+      user: {
+        id: 2,
+        email: 'john@example.com',
+        first_name: 'John',
+        last_name: 'Doe',
+      },
+    });
+
+    const candidatesRequest = httpMock.expectOne(candidatesUrl);
+    expect(candidatesRequest.request.method).toBe('GET');
+    candidatesRequest.flush([
+      {
+        id: 44,
+        user: {
+          email: 'john@example.com',
+          first_name: 'John',
+          last_name: 'Doe',
+          phone: '+330000000',
+        },
+      },
+    ]);
+
+    expect(candidateId).toBe(44);
+    expect(tokenStorageSpy.saveTokens).toHaveBeenCalledWith('access-token', 'refresh-token');
+  });
+
+  it('maps nested backend validation errors to user-friendly message', () => {
+    let actualError: string | null = null;
+
+    service
+      .signUp({
+        firstName: 'Jane',
+        lastName: 'Smith',
+        email: 'jane@example.com',
+        phone: '+33123456',
+        password: '123',
+      })
+      .subscribe({
+        next: () => fail('Expected error'),
+        error: (errorMessage: string) => {
+          actualError = errorMessage;
+        },
+      });
+
+    const createRequest = httpMock.expectOne(candidatesUrl);
+    createRequest.flush(
+      {
+        user: {
+          password: ['This password is too short. It must contain at least 8 characters.'],
+        },
+      },
+      { status: 400, statusText: 'Bad Request' },
+    );
+
+    expect(actualError).toContain('at least 8 characters');
+  });
+
+  it('refresh calls backend refresh endpoint', () => {
+    let access: string | null = null;
+
+    service.refresh('refresh-token').subscribe((response) => {
+      access = response.access;
+    });
+
+    const request = httpMock.expectOne(refreshUrl);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual({ refresh: 'refresh-token' });
+
+    request.flush({ access: 'new-access' });
+
+    expect(access).toBe('new-access');
+  });
+});

--- a/apps/candidate/src/app/core/auth/services/auth.service.ts
+++ b/apps/candidate/src/app/core/auth/services/auth.service.ts
@@ -1,18 +1,238 @@
-import { Injectable } from "@angular/core";
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, catchError, map, of, switchMap, throwError } from 'rxjs';
+
+import { environment } from '@env/environment';
+
+import { TokenStorageService } from '@core/auth/services/token-storage.service';
+
+export interface AuthenticatedCandidate {
+  candidateId: number;
+  email: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+}
+
+export interface SignInPayload {
+  email: string;
+  password: string;
+}
+
+export interface SignUpPayload {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  password: string;
+}
+
+interface LoginResponseDto {
+  access: string;
+  refresh: string;
+  user?: {
+    id: number;
+    email: string;
+    first_name: string;
+    last_name: string;
+  } | null;
+}
+
+interface CandidateDto {
+  id: number;
+  user: {
+    email: string;
+    first_name: string;
+    last_name: string;
+    phone?: string;
+  };
+}
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-  private readonly tokenKey = 'access_token';
+  private readonly http = inject(HttpClient);
+  private readonly tokenStorage = inject(TokenStorageService);
+
+  private readonly candidateProfileKey = 'candidate_profile';
+
+  private readonly authBaseUrl = `${environment.apiBaseUrl}/api/auth`;
+  private readonly candidatesUrl = `${environment.apiBaseUrl}/api/candidates/`;
 
   isAuthenticated(): boolean {
-    return !!localStorage.getItem(this.tokenKey);
+    return this.tokenStorage.isAuthenticated();
   }
 
-  setToken(token: string): void {
-    localStorage.setItem(this.tokenKey, token);
+  signIn(payload: SignInPayload): Observable<AuthenticatedCandidate> {
+    return this.http
+      .post<LoginResponseDto>(`${this.authBaseUrl}/login/`, {
+        email: payload.email,
+        password: payload.password,
+      })
+      .pipe(
+        switchMap((response) => {
+          this.persistTokens(response.access, response.refresh);
+
+          return this.resolveCandidateProfile(payload.email, {
+            firstName: response.user?.first_name ?? '',
+            lastName: response.user?.last_name ?? '',
+            phone: '',
+          });
+        }),
+        map((candidate) => {
+          this.saveAuthenticatedCandidate(candidate);
+          return candidate;
+        }),
+        catchError((error: unknown) => this.mapAuthError(error)),
+      );
+  }
+
+  signUp(payload: SignUpPayload): Observable<AuthenticatedCandidate> {
+    return this.http
+      .post<CandidateDto>(this.candidatesUrl, {
+        user: {
+          first_name: payload.firstName,
+          last_name: payload.lastName,
+          email: payload.email,
+          phone: payload.phone,
+          password: payload.password,
+        },
+      })
+      .pipe(
+        switchMap((createdCandidate) =>
+          this.signIn({
+            email: payload.email,
+            password: payload.password,
+          }).pipe(
+            map((signedInCandidate) => ({
+              ...signedInCandidate,
+              candidateId: createdCandidate.id,
+              firstName: signedInCandidate.firstName || payload.firstName,
+              lastName: signedInCandidate.lastName || payload.lastName,
+              phone: signedInCandidate.phone || payload.phone,
+            })),
+          ),
+        ),
+        map((candidate) => {
+          this.saveAuthenticatedCandidate(candidate);
+          return candidate;
+        }),
+        catchError((error: unknown) => this.mapAuthError(error)),
+      );
+  }
+
+  getAuthenticatedCandidate(): AuthenticatedCandidate | null {
+    const rawCandidate = localStorage.getItem(this.candidateProfileKey);
+    if (!rawCandidate) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(rawCandidate) as AuthenticatedCandidate;
+    } catch {
+      localStorage.removeItem(this.candidateProfileKey);
+      return null;
+    }
+  }
+
+  saveAuthenticatedCandidate(candidate: AuthenticatedCandidate): void {
+    localStorage.setItem(this.candidateProfileKey, JSON.stringify(candidate));
   }
 
   logout(): void {
-    localStorage.removeItem(this.tokenKey);
+    this.tokenStorage.clear();
+    localStorage.removeItem(this.candidateProfileKey);
+  }
+
+  refresh(refreshToken: string): Observable<{ access: string; refresh?: string }> {
+    return this.http.post<{ access: string; refresh?: string }>(`${this.authBaseUrl}/refresh/`, {
+      refresh: refreshToken,
+    });
+  }
+
+  private resolveCandidateProfile(
+    email: string,
+    fallback: { firstName: string; lastName: string; phone: string },
+  ): Observable<AuthenticatedCandidate> {
+    return this.http.get<CandidateDto[]>(this.candidatesUrl).pipe(
+      map((candidates) => {
+        const candidate = candidates.find(
+          (item) => item.user.email.toLowerCase() === email.toLowerCase(),
+        );
+
+        if (!candidate) {
+          return {
+            candidateId: Date.now(),
+            email,
+            firstName: fallback.firstName,
+            lastName: fallback.lastName,
+            phone: fallback.phone,
+          };
+        }
+
+        return {
+          candidateId: candidate.id,
+          email: candidate.user.email,
+          firstName: candidate.user.first_name,
+          lastName: candidate.user.last_name,
+          phone: candidate.user.phone ?? '',
+        };
+      }),
+      catchError(() =>
+        of({
+          candidateId: Date.now(),
+          email,
+          firstName: fallback.firstName,
+          lastName: fallback.lastName,
+          phone: fallback.phone,
+        }),
+      ),
+    );
+  }
+
+  private persistTokens(accessToken: string, refreshToken: string): void {
+    this.tokenStorage.saveTokens(accessToken, refreshToken);
+  }
+
+  private mapAuthError(error: unknown): Observable<never> {
+    if (!(error instanceof HttpErrorResponse)) {
+      return throwError(() => 'Unexpected authentication error.');
+    }
+
+    if (error.status === 0) {
+      return throwError(() => 'Cannot reach authentication service.');
+    }
+
+    const detail = this.extractErrorDetail(error.error);
+    return throwError(() => detail || 'Authentication failed.');
+  }
+
+  private extractErrorDetail(errorBody: unknown): string | null {
+    if (typeof errorBody === 'string') {
+      return errorBody;
+    }
+
+    if (Array.isArray(errorBody)) {
+      const first = errorBody[0];
+      return typeof first === 'string' ? first : this.extractErrorDetail(first);
+    }
+
+    if (!errorBody || typeof errorBody !== 'object') {
+      return null;
+    }
+
+    const typedBody = errorBody as Record<string, unknown>;
+
+    if (typeof typedBody['detail'] === 'string') {
+      return typedBody['detail'];
+    }
+
+    for (const value of Object.values(typedBody)) {
+      const extractedMessage = this.extractErrorDetail(value);
+      if (extractedMessage) {
+        return extractedMessage;
+      }
+    }
+
+    return null;
   }
 }

--- a/apps/candidate/src/app/core/auth/services/token-storage.service.spec.ts
+++ b/apps/candidate/src/app/core/auth/services/token-storage.service.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TokenStorageService } from './token-storage.service';
+
+describe('TokenStorageService', () => {
+  let service: TokenStorageService;
+
+  beforeEach(() => {
+    localStorage.clear();
+
+    TestBed.configureTestingModule({
+      providers: [TokenStorageService],
+    });
+
+    service = TestBed.inject(TokenStorageService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves and retrieves tokens', () => {
+    service.saveTokens('access', 'refresh');
+
+    expect(service.getAccessToken()).toBe('access');
+    expect(service.getRefreshToken()).toBe('refresh');
+    expect(service.isAuthenticated()).toBeTrue();
+  });
+
+  it('clears stored tokens', () => {
+    service.saveTokens('access', 'refresh');
+
+    service.clear();
+
+    expect(service.getAccessToken()).toBeNull();
+    expect(service.getRefreshToken()).toBeNull();
+    expect(service.isAuthenticated()).toBeFalse();
+  });
+});

--- a/apps/candidate/src/app/core/auth/services/token-storage.service.ts
+++ b/apps/candidate/src/app/core/auth/services/token-storage.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class TokenStorageService {
+  private readonly accessKey = 'access_token';
+  private readonly refreshKey = 'refresh_token';
+
+  getAccessToken(): string | null {
+    return localStorage.getItem(this.accessKey);
+  }
+
+  getRefreshToken(): string | null {
+    return localStorage.getItem(this.refreshKey);
+  }
+
+  saveTokens(accessToken: string, refreshToken: string): void {
+    localStorage.setItem(this.accessKey, accessToken);
+    localStorage.setItem(this.refreshKey, refreshToken);
+  }
+
+  clear(): void {
+    localStorage.removeItem(this.accessKey);
+    localStorage.removeItem(this.refreshKey);
+  }
+
+  isAuthenticated(): boolean {
+    return !!this.getAccessToken();
+  }
+}

--- a/apps/candidate/src/app/features/jobs/components/job-offer-detail-card/job-offer-detail-card.component.spec.ts
+++ b/apps/candidate/src/app/features/jobs/components/job-offer-detail-card/job-offer-detail-card.component.spec.ts
@@ -56,7 +56,7 @@ describe('JobOfferDetailCardComponent', () => {
     spyOn(component.applyClicked, 'emit');
 
     const button = fixture.debugElement.query(
-      By.css('[data-testid="apply-button"]'),
+      By.css('[data-testid="apply-button"] button'),
     ).nativeElement as HTMLButtonElement;
 
     button.click();

--- a/apps/candidate/src/app/features/jobs/pages/job-offer-detail-page/job-offer-detail.page.html
+++ b/apps/candidate/src/app/features/jobs/pages/job-offer-detail-page/job-offer-detail.page.html
@@ -31,6 +31,13 @@
   </header>
 
   <main class="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 pb-36 pt-6">
+    @if (applicationSubmitted) {
+      <app-ui-alert
+        variant="success"
+        message="Your application was sent successfully. The recruiter will contact you soon."
+      />
+    }
+
     @if (state === 'loading') {
       <section class="space-y-6">
         <div class="space-y-3">
@@ -78,10 +85,8 @@
     } @else if (state === 'error') {
       <app-ui-alert
         variant="error"
-        title="Something went wrong"
-        description="We could not load this job offer right now. Please try again later."
-      >
-      </app-ui-alert>
+        message="We could not load this job offer right now. Please try again later."
+      />
 
       <div class="flex justify-start">
         <app-ui-button-secondary
@@ -142,4 +147,62 @@
       (closed)="authModalOpen = false"
     />
   }
+
+  <app-ui-modal
+    [open]="applicationModalOpen"
+    (openChange)="onApplicationModalOpenChanged($event)"
+    title="Finalize your application"
+    size="md"
+  >
+    <form class="space-y-4" [formGroup]="applicationForm" (ngSubmit)="onApplicationSubmitted()">
+      <app-ui-text-input
+        formControlName="firstName"
+        label="First name"
+        placeholder="John"
+      />
+
+      <app-ui-text-input
+        formControlName="lastName"
+        label="Last name"
+        placeholder="Doe"
+      />
+
+      <app-ui-text-input
+        formControlName="email"
+        label="Email"
+        placeholder="candidate@example.com"
+        type="email"
+      />
+
+      <app-ui-text-input
+        formControlName="phone"
+        label="Phone"
+        placeholder="+33..."
+        type="tel"
+      />
+
+      <app-ui-textarea
+        formControlName="motivation"
+        label="Motivation"
+        hint="Describe briefly why you are a good fit for this role."
+        placeholder="Tell us about your profile and availability..."
+        [rows]="5"
+      />
+
+      @if (applicationErrorMessage) {
+        <app-ui-alert
+          variant="error"
+          [message]="applicationErrorMessage"
+        />
+      }
+
+      <div modal-actions>
+        <div class="w-full">
+          <app-ui-button-primary type="submit" [loading]="applicationSubmitting">
+            Confirm application
+          </app-ui-button-primary>
+        </div>
+      </div>
+    </form>
+  </app-ui-modal>
 </section>

--- a/apps/candidate/src/app/features/jobs/pages/job-offer-detail-page/job-offer-detail.page.spec.ts
+++ b/apps/candidate/src/app/features/jobs/pages/job-offer-detail-page/job-offer-detail.page.spec.ts
@@ -4,7 +4,9 @@ import { convertToParamMap, ActivatedRoute } from '@angular/router';
 import { By } from '@angular/platform-browser';
 import { of, throwError } from 'rxjs';
 
+import { AuthService, AuthenticatedCandidate } from '@core/auth/services/auth.service';
 import { JobOffer } from '@jobs/models/job-offer.model';
+import { JobApplicationService } from '@jobs/services/job-application.service';
 import { JobPublicApiService } from '@jobs/services/job-public-api.service';
 
 import { JobOfferDetailPageComponent } from './job-offer-detail.page';
@@ -13,6 +15,8 @@ describe('JobOfferDetailPageComponent', () => {
   let fixture: ComponentFixture<JobOfferDetailPageComponent>;
   let component: JobOfferDetailPageComponent;
   let jobPublicApiServiceSpy: jasmine.SpyObj<JobPublicApiService>;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let jobApplicationServiceSpy: jasmine.SpyObj<JobApplicationService>;
 
   const mockOffer: JobOffer = {
     id: 1,
@@ -23,6 +27,14 @@ describe('JobOfferDetailPageComponent', () => {
     department: 'Engineering',
     salary: 50000,
     createdAt: '2026-03-19T10:00:00Z',
+  };
+
+  const mockCandidate: AuthenticatedCandidate = {
+    candidateId: 4,
+    email: 'candidate@example.com',
+    firstName: 'Alice',
+    lastName: 'Martin',
+    phone: '+33102030405',
   };
 
   async function createComponentWithRouteId(routeId: string): Promise<void> {
@@ -41,6 +53,14 @@ describe('JobOfferDetailPageComponent', () => {
           provide: JobPublicApiService,
           useValue: jobPublicApiServiceSpy,
         },
+        {
+          provide: AuthService,
+          useValue: authServiceSpy,
+        },
+        {
+          provide: JobApplicationService,
+          useValue: jobApplicationServiceSpy,
+        },
       ],
     }).compileComponents();
 
@@ -53,6 +73,20 @@ describe('JobOfferDetailPageComponent', () => {
     jobPublicApiServiceSpy = jasmine.createSpyObj<JobPublicApiService>(
       'JobPublicApiService',
       ['getOfferById'],
+    );
+    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', [
+      'isAuthenticated',
+      'getAuthenticatedCandidate',
+    ]);
+    jobApplicationServiceSpy = jasmine.createSpyObj<JobApplicationService>(
+      'JobApplicationService',
+      ['applyToOffer'],
+    );
+
+    authServiceSpy.isAuthenticated.and.returnValue(false);
+    authServiceSpy.getAuthenticatedCandidate.and.returnValue(null);
+    jobApplicationServiceSpy.applyToOffer.and.returnValue(
+      of({ id: 12, position: 1, candidate: 4, status: 'applied' }),
     );
   });
 
@@ -150,7 +184,7 @@ describe('JobOfferDetailPageComponent', () => {
 
     const compiled = fixture.nativeElement as HTMLElement;
 
-    expect(compiled.textContent).toContain('Something went wrong');
+    expect(compiled.textContent).toContain('We could not load this job offer right now. Please try again later.');
   });
 
   it('should set not-found state if id is invalid', async () => {
@@ -169,12 +203,99 @@ describe('JobOfferDetailPageComponent', () => {
     spyOn(component, 'onApplyClicked');
 
     const button = fixture.debugElement.query(
-      By.css('[data-testid="apply-button"]'),
+      By.css('[data-testid="apply-button"] button'),
     ).nativeElement as HTMLButtonElement;
 
     button.click();
     fixture.detectChanges();
 
     expect(component.onApplyClicked).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens auth modal when user is not authenticated', async () => {
+    jobPublicApiServiceSpy.getOfferById.and.returnValue(of(mockOffer));
+    authServiceSpy.isAuthenticated.and.returnValue(false);
+
+    await createComponentWithRouteId('1');
+
+    component.onApplyClicked();
+
+    expect(component.authModalOpen).toBeTrue();
+    expect(component.applicationModalOpen).toBeFalse();
+  });
+
+  it('opens application modal with prefilled profile when user is authenticated', async () => {
+    jobPublicApiServiceSpy.getOfferById.and.returnValue(of(mockOffer));
+    authServiceSpy.isAuthenticated.and.returnValue(true);
+    authServiceSpy.getAuthenticatedCandidate.and.returnValue(mockCandidate);
+
+    await createComponentWithRouteId('1');
+
+    component.onApplyClicked();
+
+    expect(component.applicationModalOpen).toBeTrue();
+    expect(component.applicationForm.getRawValue()).toEqual({
+      firstName: 'Alice',
+      lastName: 'Martin',
+      email: 'candidate@example.com',
+      phone: '+33102030405',
+      motivation: '',
+    });
+  });
+
+  it('resumes flow after auth success and opens application form', async () => {
+    jobPublicApiServiceSpy.getOfferById.and.returnValue(of(mockOffer));
+    authServiceSpy.getAuthenticatedCandidate.and.returnValue(mockCandidate);
+
+    await createComponentWithRouteId('1');
+
+    component.authModalOpen = true;
+    component.onAuthSuccess();
+
+    expect(component.authModalOpen).toBeFalse();
+    expect(component.applicationModalOpen).toBeTrue();
+  });
+
+
+
+  it('does not submit when application form is invalid', async () => {
+    jobPublicApiServiceSpy.getOfferById.and.returnValue(of(mockOffer));
+    authServiceSpy.isAuthenticated.and.returnValue(true);
+    authServiceSpy.getAuthenticatedCandidate.and.returnValue(mockCandidate);
+
+    await createComponentWithRouteId('1');
+
+    component.onApplyClicked();
+    component.applicationForm.patchValue({ motivation: '' });
+
+    component.onApplicationSubmitted();
+
+    expect(jobApplicationServiceSpy.applyToOffer).not.toHaveBeenCalled();
+    expect(component.applicationSubmitted).toBeFalse();
+  });
+
+  it('submits the application when form is valid', async () => {
+    jobPublicApiServiceSpy.getOfferById.and.returnValue(of(mockOffer));
+    authServiceSpy.isAuthenticated.and.returnValue(true);
+    authServiceSpy.getAuthenticatedCandidate.and.returnValue(mockCandidate);
+
+    await createComponentWithRouteId('1');
+
+    component.onApplyClicked();
+    component.applicationForm.patchValue({ motivation: 'I can start next week.' });
+
+    component.onApplicationSubmitted();
+
+    expect(jobApplicationServiceSpy.applyToOffer).toHaveBeenCalledWith({
+      positionId: 1,
+      candidateId: 4,
+      firstName: 'Alice',
+      lastName: 'Martin',
+      email: 'candidate@example.com',
+      phone: '+33102030405',
+      motivation: 'I can start next week.',
+    });
+    expect(component.applicationSubmitted).toBeTrue();
+    expect(component.applicationModalOpen).toBeFalse();
   });
 });

--- a/apps/candidate/src/app/features/jobs/pages/job-offer-detail-page/job-offer-detail.page.ts
+++ b/apps/candidate/src/app/features/jobs/pages/job-offer-detail-page/job-offer-detail.page.ts
@@ -1,21 +1,26 @@
 import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
+import { AuthModalComponent } from '@core/auth/components/auth-modal/auth-modal.component';
+import { AuthService } from '@core/auth/services/auth.service';
 import { JobOfferDetailCardComponent } from '@jobs/components/job-offer-detail-card/job-offer-detail-card.component';
 import { JobOffer } from '@jobs/models/job-offer.model';
+import { JobApplicationService } from '@jobs/services/job-application.service';
 import { JobPublicApiService } from '@jobs/services/job-public-api.service';
+import { UiAlertComponent } from '@lib-ui/alert/alert.component';
+import { UiBadgeComponent } from '@lib-ui/badge/badge.component';
 import { UiButtonPrimaryComponent } from '@lib-ui/button-primary/button-primary.component';
 import { UiButtonSecondaryComponent } from '@lib-ui/button-secondary/button-secondary.component';
-import { UiBadgeComponent } from '@lib-ui/badge/badge.component';
-import { UiAlertComponent } from '@lib-ui/alert/alert.component';
-import { UiIconButtonComponent } from '@lib-ui/icon-button/icon-button.component';
 import { UiCardComponent } from '@lib-ui/card/card.component';
-import { UiSkeletonComponent } from '@lib-ui/skeleton/skeleton.component';
 import { UiEmptyStateComponent } from '@lib-ui/empty-state/empty-state.component';
-import { AuthService } from '@core/auth/services/auth.service';
-import { AuthModalComponent } from '@core/auth/components/auth-modal/auth-modal.component';
+import { UiIconButtonComponent } from '@lib-ui/icon-button/icon-button.component';
+import { UiModalComponent } from '@lib-ui/modal/modal.component';
+import { UiSkeletonComponent } from '@lib-ui/skeleton/skeleton.component';
+import { UiTextareaComponent } from '@lib-ui/textarea/textarea.component';
+import { UiTextInputComponent } from '@lib-ui/text-input/text-input.component';
 
 type JobOfferDetailPageState = 'loading' | 'success' | 'not-found' | 'error';
 
@@ -24,6 +29,7 @@ type JobOfferDetailPageState = 'loading' | 'success' | 'not-found' | 'error';
   standalone: true,
   imports: [
     CommonModule,
+    ReactiveFormsModule,
     AuthModalComponent,
     JobOfferDetailCardComponent,
     UiButtonPrimaryComponent,
@@ -34,17 +40,35 @@ type JobOfferDetailPageState = 'loading' | 'success' | 'not-found' | 'error';
     UiCardComponent,
     UiSkeletonComponent,
     UiEmptyStateComponent,
+    UiModalComponent,
+    UiTextInputComponent,
+    UiTextareaComponent,
   ],
   templateUrl: './job-offer-detail.page.html',
 })
 export class JobOfferDetailPageComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly jobPublicApiService = inject(JobPublicApiService);
+  private readonly jobApplicationService = inject(JobApplicationService);
   private readonly authService = inject(AuthService);
 
   authModalOpen = false;
+  applicationModalOpen = false;
+  applicationSubmitted = false;
+  applicationSubmitting = false;
+  applicationErrorMessage: string | null = null;
+
   offer: JobOffer | null = null;
   state: JobOfferDetailPageState = 'loading';
+
+  readonly applicationForm = this.formBuilder.nonNullable.group({
+    firstName: ['', [Validators.required]],
+    lastName: ['', [Validators.required]],
+    email: ['', [Validators.required, Validators.email]],
+    phone: ['', [Validators.required]],
+    motivation: ['', [Validators.required, Validators.maxLength(2000)]],
+  });
 
   ngOnInit(): void {
     const offerId = this.getOfferIdFromRoute();
@@ -66,6 +90,60 @@ export class JobOfferDetailPageComponent implements OnInit {
     this.openApplicationPreviewModal();
   }
 
+  onApplicationSubmitted(): void {
+    if (!this.offer) {
+      return;
+    }
+
+    const currentCandidate = this.authService.getAuthenticatedCandidate();
+    if (!currentCandidate) {
+      this.applicationErrorMessage = 'Please sign in again before applying.';
+      this.authModalOpen = true;
+      this.applicationModalOpen = false;
+      return;
+    }
+
+    this.applicationForm.markAllAsTouched();
+    if (this.applicationForm.invalid) {
+      return;
+    }
+
+    const formValue = this.applicationForm.getRawValue();
+    this.applicationSubmitting = true;
+    this.applicationErrorMessage = null;
+
+    this.jobApplicationService
+      .applyToOffer({
+        positionId: this.offer.id,
+        candidateId: currentCandidate.candidateId,
+        firstName: formValue.firstName,
+        lastName: formValue.lastName,
+        email: formValue.email,
+        phone: formValue.phone,
+        motivation: formValue.motivation,
+      })
+      .subscribe({
+        next: () => {
+          this.applicationSubmitting = false;
+          this.applicationSubmitted = true;
+          this.applicationModalOpen = false;
+        },
+        error: (errorResponse: HttpErrorResponse) => {
+          this.applicationSubmitting = false;
+          this.applicationErrorMessage =
+            errorResponse.status === 400
+              ? 'Your application is invalid or already submitted for this offer.'
+              : 'Unable to submit your application right now. Please retry.';
+        },
+      });
+  }
+
+  onApplicationModalOpenChanged(isOpen: boolean): void {
+    this.applicationModalOpen = isOpen;
+    if (!isOpen) {
+      this.applicationSubmitting = false;
+    }
+  }
 
   private openAuthModal(): void {
     this.authModalOpen = true;
@@ -73,13 +151,22 @@ export class JobOfferDetailPageComponent implements OnInit {
 
   onAuthSuccess(): void {
     this.authModalOpen = false;
-
-    // 🔥 KEY UX: resume flow
     this.openApplicationPreviewModal();
   }
 
   private openApplicationPreviewModal(): void {
-    // temporary → next step
+    const currentCandidate = this.authService.getAuthenticatedCandidate();
+
+    this.applicationForm.patchValue({
+      firstName: currentCandidate?.firstName ?? '',
+      lastName: currentCandidate?.lastName ?? '',
+      email: currentCandidate?.email ?? '',
+      phone: currentCandidate?.phone ?? '',
+      motivation: '',
+    });
+
+    this.applicationErrorMessage = null;
+    this.applicationModalOpen = true;
   }
 
   private getOfferIdFromRoute(): number | null {

--- a/apps/candidate/src/app/features/jobs/services/job-application.service.spec.ts
+++ b/apps/candidate/src/app/features/jobs/services/job-application.service.spec.ts
@@ -1,0 +1,74 @@
+import { provideHttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+
+import {
+  JobApplicationPayload,
+  JobApplicationService,
+} from './job-application.service';
+
+describe('JobApplicationService', () => {
+  let service: JobApplicationService;
+  let httpMock: HttpTestingController;
+
+  const expectedUrl = 'http://localhost:8000/api/jobapplications/';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        JobApplicationService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    service = TestBed.inject(JobApplicationService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('posts job application payload to API', () => {
+    const payload: JobApplicationPayload = {
+      positionId: 9,
+      candidateId: 15,
+      firstName: 'Alice',
+      lastName: 'Martin',
+      email: 'alice@example.com',
+      phone: '+3300000000',
+      motivation: 'I have 4 years of experience.',
+    };
+
+    service.applyToOffer(payload).subscribe((response) => {
+      expect(response).toEqual({
+        id: 44,
+        candidate: 15,
+        position: 9,
+        status: 'applied',
+      });
+    });
+
+    const request = httpMock.expectOne(expectedUrl);
+
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual({
+      candidate: 15,
+      position: 9,
+      status: 'applied',
+    });
+
+    request.flush({
+      id: 44,
+      candidate: 15,
+      position: 9,
+      status: 'applied',
+      created_at: '2026-04-08T10:10:00Z',
+      updated_at: '2026-04-08T10:10:00Z',
+    });
+  });
+});

--- a/apps/candidate/src/app/features/jobs/services/job-application.service.ts
+++ b/apps/candidate/src/app/features/jobs/services/job-application.service.ts
@@ -1,0 +1,54 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, map } from 'rxjs';
+
+export interface JobApplicationPayload {
+  positionId: number;
+  candidateId: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  motivation: string;
+}
+
+interface JobApplicationApiResponse {
+  id: number;
+  candidate: number;
+  position: number;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface JobApplicationResult {
+  id: number;
+  candidate: number;
+  position: number;
+  status: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class JobApplicationService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = 'http://localhost:8000/api/jobapplications/';
+
+  applyToOffer(payload: JobApplicationPayload): Observable<JobApplicationResult> {
+    const requestBody = {
+      candidate: payload.candidateId,
+      position: payload.positionId,
+      status: 'applied',
+    };
+
+    return this.http.post<JobApplicationApiResponse>(this.baseUrl, requestBody).pipe(
+      map((response) => ({
+        id: response.id,
+        candidate: response.candidate,
+        position: response.position,
+        status: response.status,
+      })),
+    );
+  }
+}

--- a/apps/frontend/src/app/app.html
+++ b/apps/frontend/src/app/app.html
@@ -1,19 +1,27 @@
-<app-top-bar
-  title="Recruitment Overview"
-  subtitle="Fleet Management Hub"
-  [notificationCount]="1"
-  [user]="{ fullName: 'Farid' }"
-/>
+<div class="min-h-screen bg-slate-950 text-slate-100">
+  <div class="fixed inset-x-0 top-0 z-50">
+    <app-top-bar
+      title="Recruitment Overview"
+      subtitle="Fleet Management Hub"
+      [notificationCount]="1"
+      [user]="{ fullName: 'Farid' }"
+    />
+  </div>
 
-<router-outlet />
+  <main class="px-0 pt-[72px] pb-[72px]">
+    <router-outlet />
+  </main>
 
-<app-menu-bar
-  [items]="[
-    { label: 'Dashboard', icon: '📊', route: '/dashboard' },
-    { label: 'Candidates', icon: '👥', route: '/candidates' },
-    { label: 'Tests', icon: '🧪', route: '/tests' },
-    { label: 'Templates', icon: '📐', route: '/templates' },
-    { label: 'Positions', icon: '📋', route: '/positions' },
-    { label: 'Pools', icon: '🗂️', route: '/pools' },
-  ]"
-/>
+  <div class="fixed inset-x-0 bottom-0 z-50">
+    <app-menu-bar
+      [items]="[
+        { label: 'Dashboard', icon: '📊', route: '/dashboard' },
+        { label: 'Candidates', icon: '👥', route: '/candidates' },
+        { label: 'Tests', icon: '🧪', route: '/tests' },
+        { label: 'Templates', icon: '📐', route: '/templates' },
+        { label: 'Positions', icon: '📋', route: '/positions' },
+        { label: 'Pools', icon: '🗂️', route: '/pools' },
+      ]"
+    />
+  </div>
+</div>

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -17,28 +17,31 @@ export const routes: Routes = [
   },
 
   {
-  path: 'positions',
-  loadChildren: () =>
-    import('./features/positions/positions.routes')
-      .then(m => m.POSITIONS_ROUTES),
+    path: 'candidates',
+    loadChildren: () =>
+      import('./features/candidates/candidates.routes').then((m) => m.CANDIDATES_ROUTES),
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['hr', 'admin', 'director', 'manager'] },
+  },
+
+  {
+    path: 'positions',
+    loadChildren: () => import('./features/positions/positions.routes').then((m) => m.POSITIONS_ROUTES),
     canActivate: [AuthGuard, RoleGuard],
     data: { roles: ['hr', 'admin', 'director', 'manager'] },
   },
 
   {
     path: 'pools',
-    loadChildren: () =>
-      import('src/app/features/pools/pool.routes')
-        .then(m => m.POOLS_ROUTES),
+    loadChildren: () => import('src/app/features/pools/pool.routes').then((m) => m.POOLS_ROUTES),
     canActivate: [AuthGuard, RoleGuard],
     data: { roles: ['hr', 'admin', 'director', 'manager'] },
   },
 
   {
     path: 'templates',
-    loadChildren: ()=>
-      import('src/app/features/test-templates/test-templates.routes')
-        .then(m => m.TEMPLATES_ROUTES),
+    loadChildren: () =>
+      import('src/app/features/test-templates/test-templates.routes').then((m) => m.TEMPLATES_ROUTES),
     canActivate: [AuthGuard, RoleGuard],
     data: { roles: ['hr', 'admin', 'director', 'manager'] },
   },

--- a/apps/frontend/src/app/app.spec.ts
+++ b/apps/frontend/src/app/app.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
+
 import { App } from './app';
 
 describe('App', () => {
@@ -14,5 +16,18 @@ describe('App', () => {
     const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
+  });
+
+  it('renders top and bottom bars in fixed containers', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const topBarContainer = fixture.debugElement.query(By.css('div.fixed.inset-x-0.top-0'));
+    const bottomBarContainer = fixture.debugElement.query(
+      By.css('div.fixed.inset-x-0.bottom-0'),
+    );
+
+    expect(topBarContainer).toBeTruthy();
+    expect(bottomBarContainer).toBeTruthy();
   });
 });

--- a/apps/frontend/src/app/features/candidates/candidates.routes.ts
+++ b/apps/frontend/src/app/features/candidates/candidates.routes.ts
@@ -1,0 +1,10 @@
+import { Routes } from '@angular/router';
+
+import { CandidatesListPage } from './pages/candidates-list.page';
+
+export const CANDIDATES_ROUTES: Routes = [
+  {
+    path: '',
+    component: CandidatesListPage,
+  },
+];

--- a/apps/frontend/src/app/features/candidates/pages/candidates-list.page.html
+++ b/apps/frontend/src/app/features/candidates/pages/candidates-list.page.html
@@ -1,0 +1,59 @@
+<section class="min-h-[calc(100vh-144px)] bg-slate-950 p-4 text-slate-100">
+  <header class="mb-4">
+    <h1 class="text-xl font-semibold">Candidates</h1>
+    <p class="text-sm text-slate-400">Browse and search candidate profiles.</p>
+  </header>
+
+  <div class="mb-4">
+    <input
+      type="search"
+      [formControl]="searchControl"
+      placeholder="Search by name, email or phone..."
+      class="w-full rounded-xl border border-slate-700 bg-slate-900 px-4 py-3 text-sm text-slate-100 outline-none focus:border-blue-500"
+    />
+  </div>
+
+  @if (isLoading) {
+    <p class="text-sm text-slate-400">Loading candidates...</p>
+  }
+
+  @if (!isLoading && errorMessage) {
+    <div class="rounded-xl border border-red-500/25 bg-red-500/10 p-3 text-sm text-red-200">
+      {{ errorMessage }}
+    </div>
+  }
+
+  @if (!isLoading && !errorMessage) {
+    @if (filteredCandidates$ | async; as candidates) {
+      <div class="space-y-3">
+        @for (candidate of candidates; track candidate.id) {
+          <article class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <h2 class="text-sm font-semibold">
+                  {{ candidate.user.first_name }} {{ candidate.user.last_name }}
+                </h2>
+                <p class="mt-1 text-xs text-slate-400">{{ candidate.user.email }}</p>
+                <p class="text-xs text-slate-500">{{ candidate.user.phone || 'No phone' }}</p>
+              </div>
+
+              <span
+                class="rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide"
+                [class.border-emerald-500/40]="candidate.status === 'pending'"
+                [class.text-emerald-300]="candidate.status === 'pending'"
+                [class.border-slate-600]="candidate.status !== 'pending'"
+                [class.text-slate-300]="candidate.status !== 'pending'"
+              >
+                {{ candidate.status }}
+              </span>
+            </div>
+          </article>
+        }
+
+        @if (candidates.length === 0) {
+          <p class="text-sm text-slate-400">No candidates found for this search.</p>
+        }
+      </div>
+    }
+  }
+</section>

--- a/apps/frontend/src/app/features/candidates/pages/candidates-list.page.spec.ts
+++ b/apps/frontend/src/app/features/candidates/pages/candidates-list.page.spec.ts
@@ -1,0 +1,90 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import {
+  CandidateDto,
+  CandidatesApiService,
+} from '@features/candidates/services/candidates-api.service';
+
+import { CandidatesListPage } from './candidates-list.page';
+
+describe('CandidatesListPage', () => {
+  let fixture: ComponentFixture<CandidatesListPage>;
+  let component: CandidatesListPage;
+  let candidatesApiSpy: jasmine.SpyObj<CandidatesApiService>;
+
+  const mockCandidates: CandidateDto[] = [
+    {
+      id: 1,
+      user: {
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john@example.com',
+        phone: '+331111111',
+      },
+      status: 'pending',
+      flag: false,
+      created_at: '2026-04-08T10:00:00Z',
+      updated_at: '2026-04-08T10:00:00Z',
+    },
+    {
+      id: 2,
+      user: {
+        first_name: 'Jane',
+        last_name: 'Smith',
+        email: 'jane@example.com',
+        phone: '+332222222',
+      },
+      status: 'approved',
+      flag: false,
+      created_at: '2026-04-08T10:00:00Z',
+      updated_at: '2026-04-08T10:00:00Z',
+    },
+  ];
+
+  beforeEach(async () => {
+    candidatesApiSpy = jasmine.createSpyObj<CandidatesApiService>('CandidatesApiService', ['list']);
+    candidatesApiSpy.list.and.returnValue(of(mockCandidates));
+
+    await TestBed.configureTestingModule({
+      imports: [CandidatesListPage],
+      providers: [{ provide: CandidatesApiService, useValue: candidatesApiSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CandidatesListPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('loads candidates on init', () => {
+    expect(candidatesApiSpy.list).toHaveBeenCalledTimes(1);
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('filters candidates by search query', (done) => {
+    component.searchControl.setValue('jane');
+
+    component.filteredCandidates$.subscribe((results) => {
+      expect(results.length).toBe(1);
+      expect(results[0].user.email).toBe('jane@example.com');
+      done();
+    });
+  });
+
+  it('shows error message when API fails', async () => {
+    candidatesApiSpy.list.and.returnValue(throwError(() => new Error('boom')));
+
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [CandidatesListPage],
+      providers: [{ provide: CandidatesApiService, useValue: candidatesApiSpy }],
+    }).compileComponents();
+
+    const errorFixture = TestBed.createComponent(CandidatesListPage);
+    errorFixture.detectChanges();
+
+    expect(errorFixture.componentInstance.errorMessage).toBe(
+      'Unable to load candidates right now.',
+    );
+  });
+});

--- a/apps/frontend/src/app/features/candidates/pages/candidates-list.page.ts
+++ b/apps/frontend/src/app/features/candidates/pages/candidates-list.page.ts
@@ -1,0 +1,103 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  inject,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { BehaviorSubject, combineLatest, map, startWith } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import {
+  CandidateDto,
+  CandidatesApiService,
+} from '@features/candidates/services/candidates-api.service';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asArrayOrResults<T>(value: unknown): T[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (isRecord(value)) {
+    const maybeResults = value['results'];
+    if (Array.isArray(maybeResults)) {
+      return maybeResults as T[];
+    }
+  }
+
+  return [];
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-candidates-list-page',
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './candidates-list.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CandidatesListPage {
+  private readonly api = inject(CandidatesApiService);
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  readonly searchControl = new FormControl('', { nonNullable: true });
+
+  private readonly candidatesSubject = new BehaviorSubject<CandidateDto[]>([]);
+  readonly candidates$ = this.candidatesSubject.asObservable();
+
+  readonly filteredCandidates$ = combineLatest([
+    this.candidates$,
+    this.searchControl.valueChanges.pipe(startWith(this.searchControl.value)),
+  ]).pipe(
+    map(([candidates, query]) => {
+      const normalizedQuery = query.trim().toLowerCase();
+      if (!normalizedQuery) {
+        return candidates;
+      }
+
+      return candidates.filter((candidate) => {
+        const fullName = `${candidate.user.first_name} ${candidate.user.last_name}`.toLowerCase();
+        const email = candidate.user.email.toLowerCase();
+        const phone = (candidate.user.phone ?? '').toLowerCase();
+
+        return (
+          fullName.includes(normalizedQuery) ||
+          email.includes(normalizedQuery) ||
+          phone.includes(normalizedQuery)
+        );
+      });
+    }),
+  );
+
+  isLoading = true;
+  errorMessage: string | null = null;
+
+  constructor() {
+    this.loadCandidates();
+  }
+
+  private loadCandidates(): void {
+    this.isLoading = true;
+    this.errorMessage = null;
+
+    this.api
+      .list()
+      .pipe(takeUntilDestroyed())
+      .subscribe({
+        next: (response) => {
+          this.candidatesSubject.next(asArrayOrResults<CandidateDto>(response));
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.errorMessage = 'Unable to load candidates right now.';
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+}

--- a/apps/frontend/src/app/features/candidates/services/candidates-api.service.spec.ts
+++ b/apps/frontend/src/app/features/candidates/services/candidates-api.service.spec.ts
@@ -1,0 +1,35 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { CandidatesApiService } from './candidates-api.service';
+
+describe('CandidatesApiService', () => {
+  let service: CandidatesApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [CandidatesApiService, provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    service = TestBed.inject(CandidatesApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('calls candidates list endpoint', () => {
+    service.list().subscribe();
+
+    const request = httpMock.expectOne('/api/candidates/');
+    expect(request.request.method).toBe('GET');
+
+    request.flush([]);
+  });
+});

--- a/apps/frontend/src/app/features/candidates/services/candidates-api.service.ts
+++ b/apps/frontend/src/app/features/candidates/services/candidates-api.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface CandidateUserDto {
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone?: string;
+}
+
+export interface CandidateDto {
+  id: number;
+  user: CandidateUserDto;
+  status: string;
+  flag: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface PaginatedResponse<T> {
+  results: T[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class CandidatesApiService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/candidates/';
+
+  list(): Observable<CandidateDto[] | PaginatedResponse<CandidateDto>> {
+    return this.http.get<CandidateDto[] | PaginatedResponse<CandidateDto>>(this.baseUrl);
+  }
+}

--- a/apps/frontend/src/app/features/positions/pages/position-applicants.page.html
+++ b/apps/frontend/src/app/features/positions/pages/position-applicants.page.html
@@ -1,0 +1,102 @@
+<section class="min-h-[calc(100vh-144px)] bg-slate-950 p-4 text-slate-100">
+  <header class="mb-4 flex items-center justify-between gap-3">
+    <div>
+      <h1 class="text-xl font-semibold">Applicants</h1>
+      <p class="text-sm text-slate-400">Position #{{ positionId }}</p>
+    </div>
+
+    <a
+      [routerLink]="['/positions']"
+      class="rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-200 hover:bg-slate-800"
+    >
+      Back to positions
+    </a>
+  </header>
+
+  <div class="mb-4">
+    <input
+      type="search"
+      [formControl]="searchControl"
+      placeholder="Search applicant name, email or status..."
+      class="w-full rounded-xl border border-slate-700 bg-slate-900 px-4 py-3 text-sm text-slate-100 outline-none focus:border-blue-500"
+    />
+  </div>
+
+  @if (isLoading) {
+    <p class="text-sm text-slate-400">Loading applicants...</p>
+  }
+
+  @if (!isLoading && errorMessage) {
+    <div class="rounded-xl border border-red-500/25 bg-red-500/10 p-3 text-sm text-red-200">
+      {{ errorMessage }}
+    </div>
+  }
+
+  @if (!isLoading && !errorMessage) {
+    @if (filteredApplicants$ | async; as applicants) {
+      <div class="space-y-3">
+        @for (applicant of applicants; track applicant.applicationId) {
+          <article class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <h2 class="text-sm font-semibold">{{ applicant.fullName }}</h2>
+                <p class="mt-1 text-xs text-slate-400">{{ applicant.email }}</p>
+                <p class="text-xs text-slate-500">{{ applicant.phone || 'No phone' }}</p>
+              </div>
+
+              <span class="rounded-full border border-blue-500/40 px-2 py-1 text-[10px] font-semibold uppercase text-blue-300">
+                {{ applicant.status }}
+              </span>
+            </div>
+
+            <p class="mt-3 text-xs text-slate-500">Applied at: {{ applicant.appliedAt }}</p>
+
+            <div class="mt-4 rounded-xl border border-slate-700 bg-slate-950/60 p-3">
+              <p class="mb-2 text-xs font-medium text-slate-300">Assign test</p>
+              <div class="flex flex-col gap-2 md:flex-row md:items-center">
+                <select
+                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-200 outline-none focus:border-blue-500"
+                  [value]="selectedTestByApplicationId[applicant.applicationId] ?? applicant.assignedTemplateId ?? ''"
+                  (change)="onSelectTest(applicant.applicationId, $any($event.target).value)"
+                >
+                  <option value="">Select a test</option>
+                  @for (test of tests; track test.id) {
+                    <option [value]="test.id">{{ test.name }}</option>
+                  }
+                </select>
+
+                <button
+                  type="button"
+                  class="rounded-lg border border-blue-500/50 bg-blue-500/10 px-3 py-2 text-xs font-semibold text-blue-200 hover:bg-blue-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+                  (click)="assignTest(applicant)"
+                  [disabled]="assigningByApplicationId[applicant.applicationId]"
+                >
+                  {{
+                    assigningByApplicationId[applicant.applicationId]
+                      ? 'Assigning...'
+                      : 'Assign test'
+                  }}
+                </button>
+              </div>
+
+              <p class="mt-2 text-[11px] text-slate-400">
+                Current test:
+                {{ applicant.assignedTemplateName || 'No test assigned yet' }}
+              </p>
+
+              @if (assignFeedbackByApplicationId[applicant.applicationId]) {
+                <p class="mt-1 text-[11px] text-slate-300">
+                  {{ assignFeedbackByApplicationId[applicant.applicationId] }}
+                </p>
+              }
+            </div>
+          </article>
+        }
+
+        @if (applicants.length === 0) {
+          <p class="text-sm text-slate-400">No applicants for this position yet.</p>
+        }
+      </div>
+    }
+  }
+</section>

--- a/apps/frontend/src/app/features/positions/pages/position-applicants.page.spec.ts
+++ b/apps/frontend/src/app/features/positions/pages/position-applicants.page.spec.ts
@@ -1,0 +1,107 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import {
+  PositionApplicant,
+  PositionApplicantsService,
+} from '@features/positions/services/position-applicants.service';
+
+import { PositionApplicantsPage } from './position-applicants.page';
+
+describe('PositionApplicantsPage', () => {
+  let fixture: ComponentFixture<PositionApplicantsPage>;
+  let component: PositionApplicantsPage;
+  let applicantsServiceSpy: jasmine.SpyObj<PositionApplicantsService>;
+
+  const applicants: PositionApplicant[] = [
+    {
+      applicationId: 1,
+      candidateId: 7,
+      fullName: 'Jane Doe',
+      email: 'jane@example.com',
+      phone: '+331111111',
+      status: 'applied',
+      appliedAt: '2026-04-08T10:00:00Z',
+      assignedTemplateId: null,
+      assignedTemplateName: null,
+    },
+  ];
+
+  beforeEach(async () => {
+    applicantsServiceSpy = jasmine.createSpyObj<PositionApplicantsService>(
+      'PositionApplicantsService',
+      ['listByPosition', 'listTests', 'assignTestToApplicant'],
+    );
+
+    applicantsServiceSpy.listByPosition.and.returnValue(of(applicants));
+    applicantsServiceSpy.listTests.and.returnValue(of([{ id: 10, name: 'English test' }]));
+    applicantsServiceSpy.assignTestToApplicant.and.returnValue(of(void 0));
+
+    await TestBed.configureTestingModule({
+      imports: [PositionApplicantsPage],
+      providers: [
+        { provide: PositionApplicantsService, useValue: applicantsServiceSpy },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: convertToParamMap({ id: '9' }) } },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PositionApplicantsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('loads applicants for current position', () => {
+    expect(applicantsServiceSpy.listByPosition).toHaveBeenCalledOnceWith(9);
+    expect(applicantsServiceSpy.listTests).toHaveBeenCalled();
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('filters applicants by search query', (done) => {
+    component.searchControl.setValue('jane');
+
+    component.filteredApplicants$.subscribe((filteredApplicants) => {
+      expect(filteredApplicants.length).toBe(1);
+      expect(filteredApplicants[0].email).toBe('jane@example.com');
+      done();
+    });
+  });
+
+  it('sets error message when API fails', async () => {
+    applicantsServiceSpy.listByPosition.and.returnValue(
+      throwError(() => new Error('failed')),
+    );
+
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [PositionApplicantsPage],
+      providers: [
+        { provide: PositionApplicantsService, useValue: applicantsServiceSpy },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: convertToParamMap({ id: '9' }) } },
+        },
+      ],
+    }).compileComponents();
+
+    const errorFixture = TestBed.createComponent(PositionApplicantsPage);
+    errorFixture.detectChanges();
+
+    expect(errorFixture.componentInstance.errorMessage).toBe(
+      'Unable to load applicants for this position.',
+    );
+  });
+
+  it('assigns selected test to applicant', () => {
+    component.onSelectTest(1, '10');
+    component.assignTest(applicants[0]);
+
+    expect(applicantsServiceSpy.assignTestToApplicant).toHaveBeenCalledOnceWith(1, {
+      templateId: 10,
+    });
+    expect(component.assignFeedbackByApplicationId[1]).toBe('Test assigned.');
+  });
+});

--- a/apps/frontend/src/app/features/positions/pages/position-applicants.page.ts
+++ b/apps/frontend/src/app/features/positions/pages/position-applicants.page.ts
@@ -1,0 +1,158 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  inject,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { BehaviorSubject, combineLatest, map, startWith } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import {
+  PositionApplicant,
+  PositionApplicantsService,
+} from '@features/positions/services/position-applicants.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-position-applicants-page',
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './position-applicants.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PositionApplicantsPage {
+  private readonly route = inject(ActivatedRoute);
+  private readonly applicantsService = inject(PositionApplicantsService);
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  readonly positionId = Number(this.route.snapshot.paramMap.get('id'));
+  readonly searchControl = new FormControl('', { nonNullable: true });
+
+  private readonly applicantsSubject = new BehaviorSubject<PositionApplicant[]>([]);
+  readonly applicants$ = this.applicantsSubject.asObservable();
+
+  readonly filteredApplicants$ = combineLatest([
+    this.applicants$,
+    this.searchControl.valueChanges.pipe(startWith(this.searchControl.value)),
+  ]).pipe(
+    map(([applicants, query]) => {
+      const normalized = query.trim().toLowerCase();
+      if (!normalized) {
+        return applicants;
+      }
+
+      return applicants.filter((applicant) => {
+        return (
+          applicant.fullName.toLowerCase().includes(normalized) ||
+          applicant.email.toLowerCase().includes(normalized) ||
+          applicant.status.toLowerCase().includes(normalized)
+        );
+      });
+    }),
+  );
+
+  isLoading = true;
+  errorMessage: string | null = null;
+  tests: { id: number; name: string }[] = [];
+  selectedTestByApplicationId: Record<number, number | null> = {};
+  assigningByApplicationId: Record<number, boolean> = {};
+  assignFeedbackByApplicationId: Record<number, string | null> = {};
+
+  constructor() {
+    this.loadTests();
+    this.loadApplicants();
+  }
+
+  onSelectTest(applicationId: number, value: string): void {
+    this.selectedTestByApplicationId[applicationId] = value ? Number(value) : null;
+  }
+
+  assignTest(applicant: PositionApplicant): void {
+    const selectedTemplateId =
+      this.selectedTestByApplicationId[applicant.applicationId] ?? applicant.assignedTemplateId;
+
+    if (!selectedTemplateId) {
+      this.assignFeedbackByApplicationId[applicant.applicationId] =
+        'Please select a test first.';
+      return;
+    }
+
+    this.assigningByApplicationId[applicant.applicationId] = true;
+    this.assignFeedbackByApplicationId[applicant.applicationId] = null;
+
+    this.applicantsService
+      .assignTestToApplicant(applicant.applicationId, { templateId: selectedTemplateId })
+      .pipe(takeUntilDestroyed())
+      .subscribe({
+        next: () => {
+          const updated = this.applicantsSubject.value.map((item) => {
+            if (item.applicationId !== applicant.applicationId) {
+              return item;
+            }
+
+            const testName =
+              this.tests.find((test) => test.id === selectedTemplateId)?.name ?? null;
+
+            return {
+              ...item,
+              assignedTemplateId: selectedTemplateId,
+              assignedTemplateName: testName,
+            };
+          });
+
+          this.applicantsSubject.next(updated);
+          this.assigningByApplicationId[applicant.applicationId] = false;
+          this.assignFeedbackByApplicationId[applicant.applicationId] = 'Test assigned.';
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.assigningByApplicationId[applicant.applicationId] = false;
+          this.assignFeedbackByApplicationId[applicant.applicationId] =
+            'Unable to assign test.';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  private loadApplicants(): void {
+    if (!Number.isInteger(this.positionId) || this.positionId <= 0) {
+      this.errorMessage = 'Invalid position identifier.';
+      this.isLoading = false;
+      return;
+    }
+
+    this.applicantsService
+      .listByPosition(this.positionId)
+      .pipe(takeUntilDestroyed())
+      .subscribe({
+        next: (applicants) => {
+          this.applicantsSubject.next(applicants);
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.errorMessage = 'Unable to load applicants for this position.';
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  private loadTests(): void {
+    this.applicantsService
+      .listTests()
+      .pipe(takeUntilDestroyed())
+      .subscribe({
+        next: (tests) => {
+          this.tests = tests;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.tests = [];
+          this.cdr.markForCheck();
+        },
+      });
+  }
+}

--- a/apps/frontend/src/app/features/positions/pages/positions-list.page.html
+++ b/apps/frontend/src/app/features/positions/pages/positions-list.page.html
@@ -86,7 +86,7 @@
 
             <div class="mt-4 flex items-end justify-between">
               <div class="text-[11px] text-slate-400">
-                <div>Applicants: —</div>
+                <a class="text-blue-300 hover:text-blue-200" [routerLink]="['/positions', p.id, 'applicants']">Applicants: view list</a>
                 <div class="text-slate-500">Closing: —</div>
               </div>
 

--- a/apps/frontend/src/app/features/positions/positions.routes.ts
+++ b/apps/frontend/src/app/features/positions/positions.routes.ts
@@ -1,18 +1,22 @@
 export const POSITIONS_ROUTES = [
-  { path: '',
-    loadComponent: () => import('./pages/positions-list.page')
-      .then(m => m.PositionsListPage),
+  {
+    path: '',
+    loadComponent: () => import('./pages/positions-list.page').then((m) => m.PositionsListPage),
   },
 
   {
     path: 'new',
-    loadComponent: () => import('./pages/position-editor.page')
-      .then(m => m.PositionEditorPage),
+    loadComponent: () => import('./pages/position-editor.page').then((m) => m.PositionEditorPage),
+  },
+
+  {
+    path: ':id/applicants',
+    loadComponent: () =>
+      import('./pages/position-applicants.page').then((m) => m.PositionApplicantsPage),
   },
 
   {
     path: ':id',
-    loadComponent: () => import('./pages/position-editor.page')
-      .then(m => m.PositionEditorPage),
+    loadComponent: () => import('./pages/position-editor.page').then((m) => m.PositionEditorPage),
   },
 ];

--- a/apps/frontend/src/app/features/positions/services/position-applicants.service.spec.ts
+++ b/apps/frontend/src/app/features/positions/services/position-applicants.service.spec.ts
@@ -1,0 +1,99 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { PositionApplicantsService } from './position-applicants.service';
+
+describe('PositionApplicantsService', () => {
+  let service: PositionApplicantsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [PositionApplicantsService, provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    service = TestBed.inject(PositionApplicantsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('maps applicants for a position with candidate details', () => {
+    let names: string[] = [];
+    let assignedTemplateName: string | null = null;
+
+    service.listByPosition(9).subscribe((applicants) => {
+      names = applicants.map((applicant) => applicant.fullName);
+      assignedTemplateName = applicants[0]?.assignedTemplateName ?? null;
+    });
+
+    const applicationsRequest = httpMock.expectOne('/api/jobapplications/');
+    const candidatesRequest = httpMock.expectOne('/api/candidates/');
+    const templatesRequest = httpMock.expectOne('/api/templates/');
+
+    applicationsRequest.flush([
+      {
+        id: 1,
+        candidate: 11,
+        position: 9,
+        status: 'applied',
+        assigned_template: 3,
+        created_at: '2026-04-08T10:00:00Z',
+      },
+      {
+        id: 2,
+        candidate: 12,
+        position: 7,
+        status: 'applied',
+        assigned_template: null,
+        created_at: '2026-04-08T09:00:00Z',
+      },
+    ]);
+
+    candidatesRequest.flush([
+      {
+        id: 11,
+        user: {
+          first_name: 'Jane',
+          last_name: 'Doe',
+          email: 'jane@example.com',
+          phone: '+330000000',
+        },
+      },
+    ]);
+
+    templatesRequest.flush([{ id: 3, name: 'French test' }]);
+
+    expect(names).toEqual(['Jane Doe']);
+    expect(assignedTemplateName).toBe('French test');
+  });
+
+  it('lists available tests', () => {
+    let testsCount = 0;
+
+    service.listTests().subscribe((tests) => {
+      testsCount = tests.length;
+    });
+
+    const req = httpMock.expectOne('/api/templates/');
+    expect(req.request.method).toBe('GET');
+    req.flush([{ id: 1, name: 'Logic test' }]);
+
+    expect(testsCount).toBe(1);
+  });
+
+  it('assigns selected test to applicant', () => {
+    service.assignTestToApplicant(42, { templateId: 12 }).subscribe();
+
+    const req = httpMock.expectOne('/api/jobapplications/42/');
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ assigned_template: 12 });
+    req.flush({});
+  });
+});

--- a/apps/frontend/src/app/features/positions/services/position-applicants.service.ts
+++ b/apps/frontend/src/app/features/positions/services/position-applicants.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, forkJoin, map } from 'rxjs';
+
+interface Paginated<T> {
+  results: T[];
+}
+
+interface JobApplicationDto {
+  id: number;
+  candidate: number;
+  position: number;
+  status: string;
+  assigned_template: number | null;
+  created_at: string;
+}
+
+interface CandidateDto {
+  id: number;
+  user: {
+    first_name: string;
+    last_name: string;
+    email: string;
+    phone?: string;
+  };
+}
+
+interface TemplateDto {
+  id: number;
+  name: string;
+}
+
+export interface PositionApplicant {
+  applicationId: number;
+  candidateId: number;
+  fullName: string;
+  email: string;
+  phone: string;
+  status: string;
+  appliedAt: string;
+  assignedTemplateId: number | null;
+  assignedTemplateName: string | null;
+}
+
+export interface AssignApplicantTestPayload {
+  templateId: number;
+}
+
+function asList<T>(value: T[] | Paginated<T>): T[] {
+  return Array.isArray(value) ? value : value.results;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PositionApplicantsService {
+  private readonly http = inject(HttpClient);
+
+  private readonly applicationsUrl = '/api/jobapplications/';
+  private readonly candidatesUrl = '/api/candidates/';
+  private readonly templatesUrl = '/api/templates/';
+
+  listByPosition(positionId: number): Observable<PositionApplicant[]> {
+    return forkJoin({
+      applications: this.http
+        .get<JobApplicationDto[] | Paginated<JobApplicationDto>>(this.applicationsUrl)
+        .pipe(map(asList)),
+      candidates: this.http
+        .get<CandidateDto[] | Paginated<CandidateDto>>(this.candidatesUrl)
+        .pipe(map(asList)),
+      templates: this.http
+        .get<TemplateDto[] | Paginated<TemplateDto>>(this.templatesUrl)
+        .pipe(map(asList)),
+    }).pipe(
+      map(({ applications, candidates, templates }) => {
+        const candidateById = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+        const templateById = new Map(templates.map((template) => [template.id, template]));
+
+        return applications
+          .filter((application) => application.position === positionId)
+          .sort((left, right) => right.created_at.localeCompare(left.created_at))
+          .map((application) => {
+            const candidate = candidateById.get(application.candidate);
+
+            return {
+              applicationId: application.id,
+              candidateId: application.candidate,
+              fullName: candidate
+                ? `${candidate.user.first_name} ${candidate.user.last_name}`.trim()
+                : `Candidate #${application.candidate}`,
+              email: candidate?.user.email ?? 'Unknown email',
+              phone: candidate?.user.phone ?? '',
+              status: application.status,
+              appliedAt: application.created_at,
+              assignedTemplateId: application.assigned_template,
+              assignedTemplateName: application.assigned_template
+                ? templateById.get(application.assigned_template)?.name ?? null
+                : null,
+            };
+          });
+      }),
+    );
+  }
+
+  listTests(): Observable<TemplateDto[]> {
+    return this.http
+      .get<TemplateDto[] | Paginated<TemplateDto>>(this.templatesUrl)
+      .pipe(map(asList));
+  }
+
+  assignTestToApplicant(
+    applicationId: number,
+    payload: AssignApplicantTestPayload,
+  ): Observable<void> {
+    return this.http
+      .patch<void>(`${this.applicationsUrl}${applicationId}/`, {
+        assigned_template: payload.templateId,
+      });
+  }
+}

--- a/libs/shared/ui/button-primary/button-primary.component.html
+++ b/libs/shared/ui/button-primary/button-primary.component.html
@@ -15,6 +15,7 @@
   [class.border-slate-700]="isDisabled"
   [class.cursor-not-allowed]="isDisabled"
   [attr.aria-busy]="loading"
+  (click)="onButtonClicked()"
 >
   @if (loading) {
     <span
@@ -24,6 +25,14 @@
 
     <span>Loading...</span>
   } @else {
-    <ng-content></ng-content>
+    @if (icon) {
+      <span class="material-symbols-outlined text-base" aria-hidden="true">{{ icon }}</span>
+    }
+
+    @if (label) {
+      <span>{{ label }}</span>
+    } @else {
+      <ng-content></ng-content>
+    }
   }
 </button>

--- a/libs/shared/ui/button-primary/button-primary.component.spec.ts
+++ b/libs/shared/ui/button-primary/button-primary.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { UiButtonPrimaryComponent } from './button-primary.component';
+
+describe('UiButtonPrimaryComponent', () => {
+  let fixture: ComponentFixture<UiButtonPrimaryComponent>;
+  let component: UiButtonPrimaryComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UiButtonPrimaryComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UiButtonPrimaryComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('renders label input when provided', () => {
+    component.label = 'Apply now';
+
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Apply now');
+  });
+
+  it('emits clicked when the button is pressed', () => {
+    spyOn(component.clicked, 'emit');
+
+    fixture.detectChanges();
+
+    const button = fixture.debugElement.query(By.css('button')).nativeElement as HTMLButtonElement;
+    button.click();
+
+    expect(component.clicked.emit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/shared/ui/button-primary/button-primary.component.ts
+++ b/libs/shared/ui/button-primary/button-primary.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -12,8 +18,20 @@ export class UiButtonPrimaryComponent {
   @Input() type: 'button' | 'submit' | 'reset' = 'button';
   @Input() disabled = false;
   @Input() loading = false;
+  @Input() label: string | null = null;
+  @Input() icon: string | null = null;
+
+  @Output() readonly clicked = new EventEmitter<void>();
 
   get isDisabled(): boolean {
     return this.disabled || this.loading;
+  }
+
+  onButtonClicked(): void {
+    if (this.isDisabled) {
+      return;
+    }
+
+    this.clicked.emit();
   }
 }

--- a/libs/shared/ui/button-secondary/button-secondary.component.html
+++ b/libs/shared/ui/button-secondary/button-secondary.component.html
@@ -2,9 +2,18 @@
   [attr.type]="type"
   [disabled]="isDisabled"
   class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-800 bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+  (click)="onButtonClicked()"
 >
   @if (!loading) {
-    <ng-content></ng-content>
+    @if (icon) {
+      <span class="material-symbols-outlined text-base" aria-hidden="true">{{ icon }}</span>
+    }
+
+    @if (label) {
+      <span>{{ label }}</span>
+    } @else {
+      <ng-content></ng-content>
+    }
   } @else {
     <span class="animate-pulse">
       <ng-content select="[loading]"></ng-content>

--- a/libs/shared/ui/button-secondary/button-secondary.component.spec.ts
+++ b/libs/shared/ui/button-secondary/button-secondary.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { UiButtonSecondaryComponent } from './button-secondary.component';
+
+describe('UiButtonSecondaryComponent', () => {
+  let fixture: ComponentFixture<UiButtonSecondaryComponent>;
+  let component: UiButtonSecondaryComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UiButtonSecondaryComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UiButtonSecondaryComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('renders label input when provided', () => {
+    component.label = 'Back to offers';
+
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Back to offers');
+  });
+
+  it('emits clicked when pressed', () => {
+    spyOn(component.clicked, 'emit');
+
+    fixture.detectChanges();
+
+    const button = fixture.debugElement.query(By.css('button')).nativeElement as HTMLButtonElement;
+    button.click();
+
+    expect(component.clicked.emit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/shared/ui/button-secondary/button-secondary.component.ts
+++ b/libs/shared/ui/button-secondary/button-secondary.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -12,8 +18,20 @@ export class UiButtonSecondaryComponent {
   @Input() type: 'button' | 'submit' | 'reset' = 'button';
   @Input() disabled = false;
   @Input() loading = false;
+  @Input() label: string | null = null;
+  @Input() icon: string | null = null;
+
+  @Output() readonly clicked = new EventEmitter<void>();
 
   get isDisabled(): boolean {
     return this.disabled || this.loading;
+  }
+
+  onButtonClicked(): void {
+    if (this.isDisabled) {
+      return;
+    }
+
+    this.clicked.emit();
   }
 }

--- a/libs/shared/ui/text-input/text-input.component.ts
+++ b/libs/shared/ui/text-input/text-input.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, Input, forwardRef, signal } from '@
 import { CommonModule } from '@angular/common';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-type UiTextInputType = 'text' | 'email' | 'number' | 'search' | 'tel' | 'url';
+type UiTextInputType = 'text' | 'email' | 'number' | 'search' | 'tel' | 'url' | 'password';
 
 @Component({
   selector: 'app-ui-text-input',


### PR DESCRIPTION
### Motivation
- Enable candidates to be created with an optional password and validated passwords, and to sign in from the candidate SPA.
- Make candidate creation public while restricting candidate management endpoints to HR roles, and add support for assigning test templates to job applications.
- Improve frontend candidate experience with an authentication modal, token handling, application flow, and several admin UI pages/components.

### Description
- Backend: extend `CandidateUserSerializer` to accept `password` with validation via `validate_password`, enforce lengths on name/phone, and map validation/unique errors to structured serializer errors; make `create`/`update` atomic and support password updates (`CandidateSerializer`).
- Backend: allow public `create` for `CandidateViewSet` while protecting list/retrieve/update/destroy with `IsAuthenticated` + `IsHrAdminOrDirector` in `get_permissions`.
- Backend: add `assigned_template` FK to `JobApplication` with migration `0002_jobapplication_assigned_template.py` and expose `assigned_template` in `JobApplicationSerializer`.
- Backend: fix export lists for position serializers/views and small permission/format corrections in `PositionViewSet` and `PublicPositionViewSet`.
- Frontend candidate SPA: add auth flow components and services (`AuthModalComponent`, `AuthService`, `TokenStorageService`, `auth.interceptor`) plus tests and specs; wire auth interceptor into `provideHttpClient` in `app.config.ts`.
- Frontend jobs/applications: add `JobApplicationService`, application modal UI and flow in job detail page, and tests; add ability to assign templates to applications via new services and pages.
- Frontend admin: add candidates list page and related API service, position applicants page and service, and multiple shared UI adjustments (button components, inputs) with tests.

### Testing
- Ran backend integration tests via `pytest` for modified suites including `farid_tests/integrations/test_candidate_crud.py` and `test_job_application_crud.py`, which exercise candidate creation/login/password validation, HR permission checks, atomic updates, and assigned template behavior; tests passed.
- Ran Angular unit/spec tests (Jasmine/Karma style) for candidate app and frontend features including `auth`, `job-application`, `candidates` and `positions` related specs (files under `apps/candidate/src/app/**/spec.ts` and `apps/frontend/src/app/**/spec.ts`) and component tests for shared UI; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d650f31c448328a10bb544f209533c)