### PR TITLE
Add evaluations workflow, position test-template assignments, role support and admin user management; frontend integration

### DIFF
--- a/apps/backend/candidates/serializers/candidate.py
+++ b/apps/backend/candidates/serializers/candidate.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 
 from candidates.models import Candidate
 from users.models import User
+from users.models import UserRoles
 
 
 class CandidateUserSerializer(serializers.ModelSerializer):
@@ -64,6 +65,7 @@ class CandidateSerializer(serializers.ModelSerializer):
                     first_name=user_data.get("first_name", ""),
                     last_name=user_data.get("last_name", ""),
                     phone=user_data.get("phone", ""),
+                    role=UserRoles.CANDIDATE,
                 )
             except IntegrityError:
                 raise self._email_already_used_error()

--- a/apps/backend/candidates/views/candidate.py
+++ b/apps/backend/candidates/views/candidate.py
@@ -1,7 +1,12 @@
-from rest_framework.viewsets import ModelViewSet
+from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet
+
 from candidates.models import Candidate
 from candidates.serializers import CandidateSerializer
+from users.models import UserRoles
 from users.permissions import IsHrAdminOrDirector
 
 
@@ -15,7 +20,22 @@ class CandidateViewSet(ModelViewSet):
         if self.action == "create":
             return [AllowAny()]
 
+        if self.action == "me":
+            return [IsAuthenticated()]
+
         if self.action in ["list", "retrieve", "update", "partial_update", "destroy"]:
             return [IsAuthenticated(), IsHrAdminOrDirector()]
 
         return [IsAuthenticated()]
+
+    @action(detail=False, methods=["get"], url_path="me")
+    def me(self, request):
+        if request.user.role != UserRoles.CANDIDATE:
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
+        candidate = self.get_queryset().filter(user=request.user).first()
+        if candidate is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = self.get_serializer(candidate)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/backend/core/urls.py
+++ b/apps/backend/core/urls.py
@@ -7,6 +7,7 @@ from positions.views import PositionViewSet, PublicPositionViewSet
 from candidates.views import CandidateViewSet
 from employees.views import EmployeeViewSet
 from recruitment.views import JobApplicationViewSet
+from users.views import UserViewSet
 
 from templates_grid.views.pools import QuestionPoolViewSet
 from templates_grid.views.questions import SkillQuestionViewSet
@@ -32,6 +33,7 @@ router.register(
 )
 
 router.register("evaluations", EvaluationViewSet, basename="evaluations")
+router.register("users", UserViewSet, basename="users")
 
 urlpatterns = [
     path("api/", include(router.urls)),

--- a/apps/backend/evaluations/migrations/0002_evaluationresponse.py
+++ b/apps/backend/evaluations/migrations/0002_evaluationresponse.py
@@ -1,0 +1,64 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "templates_grid",
+            "0004_template_difficulty_template_duration_minutes_and_more",
+        ),
+        ("evaluations", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="EvaluationResponse",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("candidate_answer", models.TextField(blank=True, default="")),
+                ("manager_comment", models.TextField(blank=True, default="")),
+                ("score", models.IntegerField(blank=True, null=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "evaluation",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="responses",
+                        to="evaluations.evaluation",
+                    ),
+                ),
+                (
+                    "question",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="evaluation_responses",
+                        to="templates_grid.skillquestion",
+                    ),
+                ),
+            ],
+            options={
+                "indexes": [
+                    models.Index(
+                        fields=["evaluation", "updated_at"],
+                        name="evaluation_evaluat_1746fc_idx",
+                    ),
+                ],
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("evaluation", "question"),
+                        name="uniq_evaluation_response_question",
+                    )
+                ],
+            },
+        ),
+    ]

--- a/apps/backend/evaluations/models/__init__.py
+++ b/apps/backend/evaluations/models/__init__.py
@@ -5,6 +5,7 @@ from .evaluation_section_assignment import (
 )
 
 from .evaluation_question import EvaluationQuestion as EvaluationQuestion
+from .evaluation_response import EvaluationResponse as EvaluationResponse
 from .evaluation import Evaluation as Evaluation
 
 __all__ = [
@@ -12,5 +13,6 @@ __all__ = [
     "EvaluationComment",
     "EvaluationSectionAssignment",
     "EvaluationQuestion",
+    "EvaluationResponse",
     "Evaluation",
 ]

--- a/apps/backend/evaluations/models/evaluation_response.py
+++ b/apps/backend/evaluations/models/evaluation_response.py
@@ -1,0 +1,33 @@
+from django.db import models
+
+
+class EvaluationResponse(models.Model):
+    evaluation = models.ForeignKey(
+        "evaluations.Evaluation",
+        on_delete=models.CASCADE,
+        related_name="responses",
+    )
+    question = models.ForeignKey(
+        "templates_grid.SkillQuestion",
+        on_delete=models.PROTECT,
+        related_name="evaluation_responses",
+    )
+    candidate_answer = models.TextField(blank=True, default="")
+    manager_comment = models.TextField(blank=True, default="")
+    score = models.IntegerField(null=True, blank=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["evaluation", "question"],
+                name="uniq_evaluation_response_question",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["evaluation", "updated_at"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"Eval {self.evaluation_id} / Q {self.question_id}"

--- a/apps/backend/evaluations/serializers/__init__.py
+++ b/apps/backend/evaluations/serializers/__init__.py
@@ -1,5 +1,19 @@
 from .answer import SkillAnswerSerializer as SkillAnswerSerializer
 from .evaluation import EvaluationSerializer as EvaluationSerializer
+from .evaluation import (
+    EvaluationQuestionnaireUpdateSerializer as EvaluationQuestionnaireUpdateSerializer,
+)
+from .evaluation import LaunchEvaluationSerializer as LaunchEvaluationSerializer
+from .evaluation import SubjectEvaluationSerializer as SubjectEvaluationSerializer
 from .evaluation import StartEvaluationSerializer as StartEvaluationSerializer
+from .evaluation import build_questionnaire_payload as build_questionnaire_payload
 
-__all__ = ["SkillAnswerSerializer", "EvaluationSerializer", "StartEvaluationSerializer"]
+__all__ = [
+    "SkillAnswerSerializer",
+    "EvaluationSerializer",
+    "EvaluationQuestionnaireUpdateSerializer",
+    "LaunchEvaluationSerializer",
+    "SubjectEvaluationSerializer",
+    "StartEvaluationSerializer",
+    "build_questionnaire_payload",
+]

--- a/apps/backend/evaluations/serializers/evaluation.py
+++ b/apps/backend/evaluations/serializers/evaluation.py
@@ -2,10 +2,19 @@ from rest_framework import serializers
 from evaluations.models import Evaluation
 from candidates.models import Candidate
 from templates_grid.models import Template
+from templates_grid.models import TemplateVersion
 from users.models import User
+from recruitment.models import JobApplication
+from positions.models import PositionTestTemplateAssignment
+from templates_grid.models import SkillQuestion
+from evaluations.models import EvaluationResponse
 
 
 class EvaluationSerializer(serializers.ModelSerializer):
+    template_name = serializers.CharField(
+        source="template_version.template.name", read_only=True
+    )
+
     class Meta:
         model = Evaluation
         fields = [
@@ -18,6 +27,7 @@ class EvaluationSerializer(serializers.ModelSerializer):
             "status",
             "subject_comment",
             "internal_comment",
+            "template_name",
             "created_at",
             "updated_at",
             "completed_at",
@@ -30,6 +40,31 @@ class EvaluationSerializer(serializers.ModelSerializer):
             "completed_at",
             "validated_at",
         ]
+
+
+class SubjectEvaluationSerializer(serializers.ModelSerializer):
+    template_name = serializers.CharField(
+        source="template_version.template.name", read_only=True
+    )
+
+    class Meta:
+        model = Evaluation
+        fields = [
+            "id",
+            "subject",
+            "application",
+            "position",
+            "template_version",
+            "assigned_to",
+            "status",
+            "subject_comment",
+            "template_name",
+            "created_at",
+            "updated_at",
+            "completed_at",
+            "validated_at",
+        ]
+        read_only_fields = fields
 
 
 class StartEvaluationSerializer(serializers.Serializer):
@@ -63,3 +98,190 @@ class StartEvaluationSerializer(serializers.Serializer):
             assigned_to=validated_data["evaluator"],
             status="in_progress",
         )
+
+
+class LaunchEvaluationSerializer(serializers.Serializer):
+    application_id = serializers.IntegerField(required=True)
+    template_id = serializers.IntegerField(required=False)
+    assigned_to_id = serializers.IntegerField(required=False)
+
+    @staticmethod
+    def _resolve_template_version(template: Template) -> TemplateVersion:
+        latest = (
+            TemplateVersion.objects.filter(template=template)
+            .order_by("-version")
+            .first()
+        )
+        if latest:
+            return latest
+        return TemplateVersion.objects.create(template=template, version=1)
+
+    def validate(self, attrs):
+        try:
+            application = JobApplication.objects.select_related(
+                "candidate__user", "position"
+            ).get(id=attrs["application_id"])
+        except JobApplication.DoesNotExist:
+            raise serializers.ValidationError(
+                {"application_id": "Unknown job application."}
+            )
+
+        duplicate = Evaluation.objects.filter(
+            application=application, status="in_progress"
+        ).exists()
+        if duplicate:
+            raise serializers.ValidationError(
+                {"application_id": "This application already has an in-progress test."}
+            )
+
+        template_pairs: list[dict] = []
+        explicit_template_id = attrs.get("template_id")
+        if explicit_template_id:
+            try:
+                template = Template.objects.get(id=explicit_template_id)
+            except Template.DoesNotExist:
+                raise serializers.ValidationError({"template_id": "Unknown template."})
+
+            template_version = self._resolve_template_version(template)
+
+            assigned_to = None
+            assigned_to_id = attrs.get("assigned_to_id")
+            if assigned_to_id is not None:
+                try:
+                    assigned_to = User.objects.get(id=assigned_to_id)
+                except User.DoesNotExist:
+                    raise serializers.ValidationError(
+                        {"assigned_to_id": "Unknown assigned user."}
+                    )
+
+            template_pairs.append(
+                {
+                    "template_version": template_version,
+                    "assigned_to": assigned_to,
+                }
+            )
+        else:
+            assignments = (
+                PositionTestTemplateAssignment.objects.select_related(
+                    "template", "manager"
+                )
+                .filter(position=application.position)
+                .order_by("order", "id")
+            )
+            if not assignments.exists():
+                fallback_template = (
+                    Template.objects.filter(is_active=True)
+                    .order_by("-updated_at", "-id")
+                    .first()
+                )
+                if not fallback_template:
+                    raise serializers.ValidationError(
+                        {
+                            "application_id": (
+                                "No active templates are available to launch a test."
+                            )
+                        }
+                    )
+                template_pairs.append(
+                    {
+                        "template_version": self._resolve_template_version(
+                            fallback_template
+                        ),
+                        "assigned_to": None,
+                    }
+                )
+                attrs["application"] = application
+                attrs["template_pairs"] = template_pairs
+                return attrs
+
+            for assignment in assignments:
+                template_version = self._resolve_template_version(assignment.template)
+                template_pairs.append(
+                    {
+                        "template_version": template_version,
+                        "assigned_to": assignment.manager,
+                    }
+                )
+
+        attrs["application"] = application
+        attrs["template_pairs"] = template_pairs
+        return attrs
+
+    def create(self, validated_data):
+        application = validated_data["application"]
+        evaluations = []
+        for pair in validated_data["template_pairs"]:
+            evaluation = Evaluation.objects.create(
+                subject=application.candidate.user,
+                application=application,
+                position=application.position,
+                template_version=pair["template_version"],
+                assigned_to=pair["assigned_to"],
+                status="in_progress",
+            )
+            evaluations.append(evaluation)
+        return evaluations
+
+
+class EvaluationQuestionnaireAnswerInputSerializer(serializers.Serializer):
+    question_id = serializers.IntegerField()
+    candidate_answer = serializers.CharField(required=False, allow_blank=True)
+    manager_comment = serializers.CharField(required=False, allow_blank=True)
+    score = serializers.IntegerField(required=False, allow_null=True)
+
+
+class EvaluationQuestionnaireUpdateSerializer(serializers.Serializer):
+    answers = EvaluationQuestionnaireAnswerInputSerializer(many=True)
+
+    def validate_answers(self, value):
+        if not value:
+            raise serializers.ValidationError("At least one answer is required.")
+        return value
+
+
+class EvaluationQuestionnaireQuestionSerializer(serializers.Serializer):
+    question_id = serializers.IntegerField()
+    title = serializers.CharField()
+    text = serializers.CharField()
+    is_mandatory = serializers.BooleanField()
+    points = serializers.IntegerField()
+    candidate_answer = serializers.CharField(allow_blank=True)
+    manager_comment = serializers.CharField(allow_blank=True)
+    score = serializers.IntegerField(allow_null=True)
+
+
+def build_questionnaire_payload(evaluation: Evaluation) -> dict:
+    template = evaluation.template_version.template
+    rules = template.pool_rules.select_related("pool").all().order_by("order", "id")
+    pool_ids = [rule.pool_id for rule in rules]
+    questions = SkillQuestion.objects.filter(pool_id__in=pool_ids).order_by(
+        "order", "id"
+    )
+    responses_by_question = {
+        response.question_id: response
+        for response in EvaluationResponse.objects.filter(
+            evaluation=evaluation
+        ).select_related("question")
+    }
+
+    serialized_questions = []
+    for question in questions:
+        response = responses_by_question.get(question.id)
+        serialized_questions.append(
+            {
+                "question_id": question.id,
+                "title": question.title,
+                "text": question.text,
+                "is_mandatory": question.is_mandatory,
+                "points": question.points,
+                "candidate_answer": response.candidate_answer if response else "",
+                "manager_comment": response.manager_comment if response else "",
+                "score": response.score if response else None,
+            }
+        )
+
+    return {
+        "evaluation_id": evaluation.id,
+        "template_name": template.name,
+        "questions": serialized_questions,
+    }

--- a/apps/backend/evaluations/views/evaluation.py
+++ b/apps/backend/evaluations/views/evaluation.py
@@ -1,6 +1,20 @@
+from django.db.models import Q
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 from evaluations.models.evaluation import Evaluation
-from evaluations.serializers import EvaluationSerializer
+from evaluations.serializers import (
+    EvaluationSerializer,
+    EvaluationQuestionnaireUpdateSerializer,
+    LaunchEvaluationSerializer,
+    SubjectEvaluationSerializer,
+    build_questionnaire_payload,
+)
+from templates_grid.models import SkillQuestion
+from users.models import User, UserRoles
+from users.permissions import IsHrAdminOrDirector
 
 
 class EvaluationViewSet(ModelViewSet):
@@ -12,3 +26,108 @@ class EvaluationViewSet(ModelViewSet):
         .order_by("id")
     )
     serializer_class = EvaluationSerializer
+
+    def get_permissions(self):
+        if self.action in ["create", "update", "partial_update", "destroy", "launch"]:
+            return [IsAuthenticated(), IsHrAdminOrDirector()]
+        return [IsAuthenticated()]
+
+    def get_queryset(self):
+        queryset = self.queryset
+        user = self.request.user
+
+        if user.role in {UserRoles.HR, UserRoles.ADMIN, UserRoles.DIRECTOR}:
+            return queryset
+
+        if user.role == UserRoles.MANAGER:
+            return queryset.filter(assigned_to=user)
+
+        if user.role in {UserRoles.CANDIDATE, UserRoles.DRIVER, UserRoles.EMPLOYEE}:
+            return queryset.filter(subject=user)
+
+        return queryset.none()
+
+    def get_serializer_class(self):
+        if self.action == "launch":
+            return LaunchEvaluationSerializer
+
+        user = self.request.user
+
+        if user.role in {UserRoles.CANDIDATE, UserRoles.DRIVER, UserRoles.EMPLOYEE}:
+            return SubjectEvaluationSerializer
+
+        return EvaluationSerializer
+
+    @action(detail=False, methods=["post"], url_path="launch")
+    def launch(self, request):
+        serializer = LaunchEvaluationSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        evaluations = serializer.save()
+        output = EvaluationSerializer(evaluations, many=True)
+        return Response(output.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=False, methods=["get"], url_path="managers")
+    def managers(self, request):
+        query = request.query_params.get("q", "").strip()
+        managers = User.objects.filter(role=UserRoles.MANAGER, is_active=True).order_by(
+            "first_name", "last_name", "email"
+        )
+        if query:
+            managers = managers.filter(
+                Q(first_name__icontains=query)
+                | Q(last_name__icontains=query)
+                | Q(email__icontains=query)
+            )
+        payload = [
+            {
+                "id": manager.id,
+                "full_name": manager.full_name or manager.email,
+                "email": manager.email,
+            }
+            for manager in managers
+        ]
+        return Response(payload, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=["get"], url_path="questionnaire")
+    def questionnaire(self, request, pk=None):
+        evaluation = self.get_object()
+        payload = build_questionnaire_payload(evaluation)
+        return Response(payload, status=status.HTTP_200_OK)
+
+    @questionnaire.mapping.post
+    def save_questionnaire(self, request, pk=None):
+        evaluation = self.get_object()
+        serializer = EvaluationQuestionnaireUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        allowed_question_ids = set(
+            SkillQuestion.objects.filter(
+                pool_id__in=evaluation.template_version.template.pool_rules.values_list(
+                    "pool_id", flat=True
+                )
+            ).values_list("id", flat=True)
+        )
+
+        for answer in serializer.validated_data["answers"]:
+            question_id = answer["question_id"]
+            if question_id not in allowed_question_ids:
+                return Response(
+                    {
+                        "answers": [
+                            f"Question {question_id} does not belong to this template."
+                        ]
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            candidate_answer = answer.get("candidate_answer", "")
+            manager_comment = answer.get("manager_comment", "")
+            score = answer.get("score")
+
+            response, _ = evaluation.responses.get_or_create(question_id=question_id)
+            response.candidate_answer = candidate_answer
+            response.manager_comment = manager_comment
+            response.score = score
+            response.save()
+
+        payload = build_questionnaire_payload(evaluation)
+        return Response(payload, status=status.HTTP_200_OK)

--- a/apps/backend/farid_tests/factories/candidates.py
+++ b/apps/backend/farid_tests/factories/candidates.py
@@ -7,6 +7,7 @@ import uuid
 
 from candidates.models import Candidate
 from farid_tests.factories.users import UserFactory
+from users.models import UserRoles
 
 
 @dataclass(frozen=True)
@@ -31,6 +32,7 @@ class CandidateFactory:
                 last_name=last_name,
                 phone=phone,
                 password=None,
+                role=UserRoles.CANDIDATE,
             )
 
         return Candidate.objects.create(

--- a/apps/backend/farid_tests/integrations/test_candidate_crud.py
+++ b/apps/backend/farid_tests/integrations/test_candidate_crud.py
@@ -45,6 +45,7 @@ def test_create_candidate_success(api_client):
     assert candidate.user.first_name == "Jean"
     assert candidate.user.last_name == "Dupont"
     assert candidate.user.phone == "0601020304"
+    assert candidate.user.role == UserRoles.CANDIDATE
     assert candidate.status == "pending"
     assert candidate.flag is False
 
@@ -260,6 +261,32 @@ def test_list_candidates_denied_for_authenticated_non_hr_user(api_client):
     api_client.force_authenticate(user=employee_user)
     url = reverse("candidates-list")
 
+    response = api_client.get(url)
+
+    assert response.status_code == 403
+
+
+def test_candidate_me_returns_authenticated_candidate(api_client):
+    candidate = CandidateFactory.create(email="self@example.com")
+    api_client.force_authenticate(user=candidate.user)
+
+    url = reverse("candidates-me")
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    assert response.data["id"] == candidate.id
+    assert response.data["user"]["email"] == candidate.user.email
+
+
+def test_candidate_me_forbidden_for_non_candidate(api_client):
+    hr_user = UserFactory.create(
+        email="hr.me@example.com",
+        password="Secret123",
+        role=UserRoles.HR,
+    )
+    api_client.force_authenticate(user=hr_user)
+
+    url = reverse("candidates-me")
     response = api_client.get(url)
 
     assert response.status_code == 403

--- a/apps/backend/farid_tests/integrations/test_evaluation_crud.py
+++ b/apps/backend/farid_tests/integrations/test_evaluation_crud.py
@@ -6,6 +6,16 @@ from evaluations.models.evaluation import Evaluation
 from farid_tests.factories.users import UserFactory
 from farid_tests.factories.positions import PositionFactory
 from farid_tests.factories.templates_grid import TemplateFactory, TemplateVersionFactory
+from farid_tests.factories.recruitment import JobApplicationFactory
+from positions.models import PositionTestTemplateAssignment
+from users.models import UserRoles
+from templates_grid.models import (
+    QuestionPool,
+    SkillQuestion,
+    TemplateVersion,
+    TemplatePoolRule,
+    TemplateSection,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -16,7 +26,15 @@ def _unwrap_list_response(data):
     return data["results"] if isinstance(data, dict) and "results" in data else data
 
 
+def _authenticate_as_hr(api_client):
+    user = UserFactory.create(
+        email="hr-evaluations@example.com", password="Passw0rd!", role=UserRoles.HR
+    )
+    api_client.force_authenticate(user=user)
+
+
 def test_create_evaluation_success(api_client):
+    _authenticate_as_hr(api_client)
     subject = UserFactory.create(email="cand@example.com", password=None)
     template = TemplateFactory.create(name="Driver Template")
     template_version = TemplateVersionFactory.create(template=template, version=1)
@@ -45,6 +63,7 @@ def test_create_evaluation_success(api_client):
 
 
 def test_create_evaluation_missing_fields(api_client):
+    _authenticate_as_hr(api_client)
     url = reverse(f"{BASENAME}-list")
     res = api_client.post(url, {}, format="json")
 
@@ -55,6 +74,7 @@ def test_create_evaluation_missing_fields(api_client):
 
 
 def test_list_evaluations(api_client):
+    _authenticate_as_hr(api_client)
     # Create 2 evals via ORM (independent of API create)
     subject = UserFactory.create(email="s1@example.com", password=None)
     template_version = TemplateVersionFactory.create(
@@ -77,6 +97,7 @@ def test_list_evaluations(api_client):
 
 
 def test_retrieve_evaluation(api_client):
+    _authenticate_as_hr(api_client)
     subject = UserFactory.create(email="s2@example.com", password=None)
     template_version = TemplateVersionFactory.create(
         template=TemplateFactory.create(), version=1
@@ -93,6 +114,7 @@ def test_retrieve_evaluation(api_client):
 
 
 def test_update_evaluation_status(api_client):
+    _authenticate_as_hr(api_client)
     subject = UserFactory.create(email="s3@example.com", password=None)
     template_version = TemplateVersionFactory.create(
         template=TemplateFactory.create(), version=1
@@ -108,3 +130,359 @@ def test_update_evaluation_status(api_client):
 
     ev.refresh_from_db()
     assert ev.status == "completed"
+
+
+def test_manager_only_lists_assigned_evaluations(api_client):
+    manager = UserFactory.create(
+        email="manager@example.com", password="Passw0rd!", role=UserRoles.MANAGER
+    )
+    other_manager = UserFactory.create(
+        email="manager2@example.com", password="Passw0rd!", role=UserRoles.MANAGER
+    )
+    subject = UserFactory.create(email="subject-manager@example.com", password=None)
+    template_version = TemplateVersionFactory.create(
+        template=TemplateFactory.create(), version=1
+    )
+
+    owned = Evaluation.objects.create(
+        subject=subject, template_version=template_version, assigned_to=manager
+    )
+    Evaluation.objects.create(
+        subject=subject, template_version=template_version, assigned_to=other_manager
+    )
+
+    api_client.force_authenticate(user=manager)
+    url = reverse(f"{BASENAME}-list")
+    res = api_client.get(url)
+
+    assert res.status_code == 200
+    items = _unwrap_list_response(res.data)
+    assert len(items) == 1
+    assert items[0]["id"] == owned.id
+
+
+def test_candidate_can_view_own_evaluation_without_internal_comment(api_client):
+    candidate_user = UserFactory.create(
+        email="candidate-view@example.com",
+        password="Passw0rd!",
+        role=UserRoles.CANDIDATE,
+    )
+    template_version = TemplateVersionFactory.create(
+        template=TemplateFactory.create(), version=1
+    )
+    evaluation = Evaluation.objects.create(
+        subject=candidate_user,
+        template_version=template_version,
+        subject_comment="Public summary",
+        internal_comment="Internal-only notes",
+    )
+
+    api_client.force_authenticate(user=candidate_user)
+    url = reverse(f"{BASENAME}-detail", args=[evaluation.id])
+    res = api_client.get(url)
+
+    assert res.status_code == 200
+    assert res.data["id"] == evaluation.id
+    assert "internal_comment" not in res.data
+    assert res.data["subject_comment"] == "Public summary"
+
+
+def test_launch_evaluation_from_application_success(api_client):
+    _authenticate_as_hr(api_client)
+    template = TemplateFactory.create(name="Launch Template")
+    template_version = TemplateVersionFactory.create(template=template, version=1)
+    application = JobApplicationFactory.create()
+
+    url = reverse(f"{BASENAME}-launch")
+    payload = {
+        "application_id": application.id,
+        "template_id": template.id,
+    }
+    res = api_client.post(url, payload, format="json")
+
+    assert res.status_code == 201
+    assert isinstance(res.data, list)
+    assert len(res.data) == 1
+    assert res.data[0]["application"] == application.id
+    assert res.data[0]["template_version"] == template_version.id
+    assert res.data[0]["subject"] == application.candidate.user.id
+    assert res.data[0]["status"] == "in_progress"
+
+
+def test_launch_evaluation_rejects_duplicate_in_progress_for_same_application(
+    api_client,
+):
+    _authenticate_as_hr(api_client)
+    template = TemplateFactory.create(name="Launch Template Duplicate")
+    template_version = TemplateVersionFactory.create(template=template, version=1)
+    application = JobApplicationFactory.create()
+
+    Evaluation.objects.create(
+        subject=application.candidate.user,
+        application=application,
+        position=application.position,
+        template_version=template_version,
+        status="in_progress",
+    )
+
+    url = reverse(f"{BASENAME}-launch")
+    payload = {
+        "application_id": application.id,
+        "template_id": template.id,
+    }
+    res = api_client.post(url, payload, format="json")
+
+    assert res.status_code == 400
+    assert "application_id" in res.data
+
+
+def test_launch_evaluation_uses_all_position_templates_with_manager_assignment(
+    api_client,
+):
+    _authenticate_as_hr(api_client)
+    manager = UserFactory.create(
+        email="assigned-manager@example.com",
+        password="Passw0rd!",
+        role=UserRoles.MANAGER,
+    )
+    application = JobApplicationFactory.create()
+    template_one = TemplateFactory.create(name="Template 1")
+    template_two = TemplateFactory.create(name="Template 2")
+    template_one_version = TemplateVersionFactory.create(
+        template=template_one, version=1
+    )
+    template_two_version = TemplateVersionFactory.create(
+        template=template_two, version=1
+    )
+
+    PositionTestTemplateAssignment.objects.create(
+        position=application.position,
+        template=template_one,
+        manager=manager,
+        order=0,
+    )
+    PositionTestTemplateAssignment.objects.create(
+        position=application.position,
+        template=template_two,
+        manager=None,
+        order=1,
+    )
+
+    url = reverse(f"{BASENAME}-launch")
+    res = api_client.post(url, {"application_id": application.id}, format="json")
+
+    assert res.status_code == 201
+    assert len(res.data) == 2
+
+    template_versions = {row["template_version"] for row in res.data}
+    assert template_versions == {template_one_version.id, template_two_version.id}
+
+    manager_by_template = {
+        row["template_version"]: row["assigned_to"] for row in res.data
+    }
+    assert manager_by_template[template_one_version.id] == manager.id
+    assert manager_by_template[template_two_version.id] is None
+
+
+def test_launch_evaluation_creates_missing_version_for_position_template(api_client):
+    _authenticate_as_hr(api_client)
+    application = JobApplicationFactory.create()
+    template_without_version = TemplateFactory.create(name="Template Without Version")
+    PositionTestTemplateAssignment.objects.create(
+        position=application.position,
+        template=template_without_version,
+        manager=None,
+        order=0,
+    )
+
+    url = reverse(f"{BASENAME}-launch")
+    res = api_client.post(url, {"application_id": application.id}, format="json")
+
+    assert res.status_code == 201
+    assert len(res.data) == 1
+    created_version = TemplateVersion.objects.get(template=template_without_version)
+    assert created_version.version == 1
+    assert res.data[0]["template_version"] == created_version.id
+
+
+def test_launch_evaluation_creates_missing_version_for_explicit_template(api_client):
+    _authenticate_as_hr(api_client)
+    application = JobApplicationFactory.create()
+    template_without_version = TemplateFactory.create(name="Template Without Version")
+
+    url = reverse(f"{BASENAME}-launch")
+    res = api_client.post(
+        url,
+        {
+            "application_id": application.id,
+            "template_id": template_without_version.id,
+        },
+        format="json",
+    )
+
+    assert res.status_code == 201
+    assert len(res.data) == 1
+    created_version = TemplateVersion.objects.get(template=template_without_version)
+    assert created_version.version == 1
+    assert res.data[0]["template_version"] == created_version.id
+
+
+def test_launch_evaluation_uses_fallback_active_template_without_assignments(
+    api_client,
+):
+    _authenticate_as_hr(api_client)
+    application = JobApplicationFactory.create()
+    fallback_template = TemplateFactory.create(name="Fallback Active Template")
+
+    url = reverse(f"{BASENAME}-launch")
+    res = api_client.post(url, {"application_id": application.id}, format="json")
+
+    assert res.status_code == 201
+    assert len(res.data) == 1
+    created_version = TemplateVersion.objects.get(template=fallback_template)
+    assert created_version.version == 1
+    assert res.data[0]["template_version"] == created_version.id
+    assert res.data[0]["application"] == application.id
+
+
+def test_evaluation_questionnaire_get_and_save_answers(api_client):
+    _authenticate_as_hr(api_client)
+    application = JobApplicationFactory.create()
+    template = TemplateFactory.create(name="Questionnaire Template")
+    template_version = TemplateVersionFactory.create(template=template, version=1)
+    section = TemplateSection.objects.create(template=template, name="Core", order=0)
+    pool = QuestionPool.objects.create(name="Pool A", code="POOL_A")
+    TemplatePoolRule.objects.create(
+        template=template, section=section, pool=pool, random_count=0, order=0
+    )
+    question = SkillQuestion.objects.create(
+        pool=pool,
+        title="Road safety",
+        text="Describe road safety checks.",
+        is_mandatory=True,
+        points=10,
+    )
+    evaluation = Evaluation.objects.create(
+        subject=application.candidate.user,
+        application=application,
+        position=application.position,
+        template_version=template_version,
+        status="in_progress",
+    )
+
+    url = reverse(f"{BASENAME}-questionnaire", args=[evaluation.id])
+    get_res = api_client.get(url)
+
+    assert get_res.status_code == 200
+    assert get_res.data["evaluation_id"] == evaluation.id
+    assert len(get_res.data["questions"]) == 1
+    assert get_res.data["questions"][0]["question_id"] == question.id
+
+    post_res = api_client.post(
+        url,
+        {
+            "answers": [
+                {
+                    "question_id": question.id,
+                    "candidate_answer": "Candidate answer",
+                    "manager_comment": "Manager comment",
+                    "score": 8,
+                }
+            ]
+        },
+        format="json",
+    )
+
+    assert post_res.status_code == 200
+    assert post_res.data["questions"][0]["candidate_answer"] == "Candidate answer"
+    assert post_res.data["questions"][0]["manager_comment"] == "Manager comment"
+    assert post_res.data["questions"][0]["score"] == 8
+
+
+def test_evaluation_questionnaire_rejects_foreign_question(api_client):
+    _authenticate_as_hr(api_client)
+    application = JobApplicationFactory.create()
+    template = TemplateFactory.create(name="Questionnaire Foreign Template")
+    template_version = TemplateVersionFactory.create(template=template, version=1)
+    evaluation = Evaluation.objects.create(
+        subject=application.candidate.user,
+        application=application,
+        position=application.position,
+        template_version=template_version,
+        status="in_progress",
+    )
+    foreign_pool = QuestionPool.objects.create(name="Foreign", code="FOREIGN_POOL")
+    foreign_question = SkillQuestion.objects.create(
+        pool=foreign_pool, title="Foreign", text="Foreign question", points=5
+    )
+
+    url = reverse(f"{BASENAME}-questionnaire", args=[evaluation.id])
+    res = api_client.post(
+        url,
+        {
+            "answers": [
+                {
+                    "question_id": foreign_question.id,
+                    "candidate_answer": "X",
+                    "manager_comment": "",
+                    "score": 1,
+                }
+            ]
+        },
+        format="json",
+    )
+
+    assert res.status_code == 400
+    assert "answers" in res.data
+
+
+def test_managers_endpoint_lists_active_managers(api_client):
+    _authenticate_as_hr(api_client)
+    active_manager = UserFactory.create(
+        email="active-manager@example.com",
+        first_name="Alice",
+        last_name="Martin",
+        role=UserRoles.MANAGER,
+        is_active=True,
+    )
+    UserFactory.create(
+        email="inactive-manager@example.com",
+        role=UserRoles.MANAGER,
+        is_active=False,
+    )
+    UserFactory.create(
+        email="employee@example.com", role=UserRoles.EMPLOYEE, is_active=True
+    )
+
+    url = reverse(f"{BASENAME}-managers")
+    res = api_client.get(url)
+
+    assert res.status_code == 200
+    ids = {row["id"] for row in res.data}
+    assert active_manager.id in ids
+    assert len(res.data) == 1
+
+
+def test_managers_endpoint_supports_search(api_client):
+    _authenticate_as_hr(api_client)
+    UserFactory.create(
+        email="anna.manager@example.com",
+        first_name="Anna",
+        last_name="Manager",
+        role=UserRoles.MANAGER,
+        is_active=True,
+    )
+    UserFactory.create(
+        email="bob.manager@example.com",
+        first_name="Bob",
+        last_name="Manager",
+        role=UserRoles.MANAGER,
+        is_active=True,
+    )
+
+    url = reverse(f"{BASENAME}-managers")
+    res = api_client.get(url, {"q": "anna"})
+
+    assert res.status_code == 200
+    assert len(res.data) == 1
+    assert res.data[0]["email"] == "anna.manager@example.com"

--- a/apps/backend/farid_tests/integrations/test_job_application_crud.py
+++ b/apps/backend/farid_tests/integrations/test_job_application_crud.py
@@ -4,7 +4,9 @@ from django.urls import reverse
 
 from farid_tests.factories.candidates import CandidateFactory
 from farid_tests.factories.positions import PositionFactory
+from farid_tests.factories.users import UserFactory
 from recruitment.models.job_application import JobApplication
+from users.models import UserRoles
 
 pytestmark = pytest.mark.django_db
 
@@ -15,7 +17,15 @@ def _unwrap_list_response(data):
     return data["results"] if isinstance(data, dict) and "results" in data else data
 
 
+def _authenticate_as_hr(api_client):
+    user = UserFactory.create(
+        email="hr-job-apps@example.com", password="Passw0rd!", role=UserRoles.HR
+    )
+    api_client.force_authenticate(user=user)
+
+
 def test_create_job_application_success(api_client):
+    _authenticate_as_hr(api_client)
     candidate = CandidateFactory.create(email="cand@app.com")
     position = PositionFactory.create(title="Truck Driver")
 
@@ -33,6 +43,7 @@ def test_create_job_application_success(api_client):
 
 
 def test_create_job_application_duplicate_rejected(api_client):
+    _authenticate_as_hr(api_client)
     candidate = CandidateFactory.create(email="cand2@app.com")
     position = PositionFactory.create(title="Forklift Driver")
 
@@ -49,6 +60,7 @@ def test_create_job_application_duplicate_rejected(api_client):
 
 
 def test_list_job_applications(api_client):
+    _authenticate_as_hr(api_client)
     JobApplication.objects.all().delete()
     JobApplication.objects.create(
         candidate=CandidateFactory.create(), position=PositionFactory.create()
@@ -66,6 +78,7 @@ def test_list_job_applications(api_client):
 
 
 def test_retrieve_job_application(api_client):
+    _authenticate_as_hr(api_client)
     app = JobApplication.objects.create(
         candidate=CandidateFactory.create(), position=PositionFactory.create()
     )
@@ -78,6 +91,7 @@ def test_retrieve_job_application(api_client):
 
 
 def test_update_job_application_status(api_client):
+    _authenticate_as_hr(api_client)
     app = JobApplication.objects.create(
         candidate=CandidateFactory.create(), position=PositionFactory.create()
     )
@@ -89,3 +103,42 @@ def test_update_job_application_status(api_client):
 
     app.refresh_from_db()
     assert app.status == "in_review"
+
+
+def test_candidate_can_only_create_for_own_profile(api_client):
+    candidate = CandidateFactory.create(email="owner@app.com")
+    other_candidate = CandidateFactory.create(email="other@app.com")
+    position = PositionFactory.create(title="Driver A")
+
+    api_client.force_authenticate(user=candidate.user)
+    url = reverse(f"{BASENAME}-list")
+
+    res = api_client.post(
+        url,
+        {"candidate": other_candidate.id, "position": position.id, "status": "applied"},
+        format="json",
+    )
+
+    assert res.status_code == 403
+
+
+def test_candidate_list_is_scoped_to_own_applications(api_client):
+    owned_candidate = CandidateFactory.create(email="owned@app.com")
+    other_candidate = CandidateFactory.create(email="foreign@app.com")
+    owned_application = JobApplication.objects.create(
+        candidate=owned_candidate,
+        position=PositionFactory.create(title="Owned position"),
+    )
+    JobApplication.objects.create(
+        candidate=other_candidate,
+        position=PositionFactory.create(title="Foreign position"),
+    )
+
+    api_client.force_authenticate(user=owned_candidate.user)
+    url = reverse(f"{BASENAME}-list")
+    res = api_client.get(url)
+
+    assert res.status_code == 200
+    items = _unwrap_list_response(res.data)
+    assert len(items) == 1
+    assert items[0]["id"] == owned_application.id

--- a/apps/backend/farid_tests/integrations/test_position_crud.py
+++ b/apps/backend/farid_tests/integrations/test_position_crud.py
@@ -1,12 +1,14 @@
 # farid_tests/integration/test_position_crud.py
 import pytest
 from django.urls import reverse
+from django.db.utils import ProgrammingError
 
 from users.models.roles import UserRoles
 from farid_tests.factories.users import UserFactory
 from positions.models import Position
 from farid_tests.factories.companies import CompanyFactory
 from farid_tests.factories.positions import PositionFactory
+from farid_tests.factories.templates_grid import TemplateFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -116,3 +118,84 @@ def test_delete_position(api_client):
 
     if response.status_code in (204, 200):
         assert not Position.objects.filter(id=pos.id).exists()
+
+
+def test_set_and_get_position_test_templates(api_client):
+    admin = UserFactory.create(is_staff=True, role=UserRoles.ADMIN)
+    manager = UserFactory.create(role=UserRoles.MANAGER)
+    position = PositionFactory.create()
+    template = TemplateFactory.create(name="Driver Skills")
+    url = reverse("positions-test-templates", args=[position.id])
+    api_client.force_authenticate(user=admin)
+
+    put_res = api_client.put(
+        url,
+        {
+            "assignments": [
+                {"template_id": template.id, "manager_id": manager.id, "order": 0}
+            ]
+        },
+        format="json",
+    )
+    assert put_res.status_code == 200
+    assert len(put_res.data) == 1
+    assert put_res.data[0]["template"] == template.id
+    assert put_res.data[0]["manager_id"] == manager.id
+
+    get_res = api_client.get(url)
+    assert get_res.status_code == 200
+    assert len(get_res.data) == 1
+    assert get_res.data[0]["template_name"] == "Driver Skills"
+
+
+def test_get_position_test_templates_returns_503_when_table_missing(
+    api_client, monkeypatch
+):
+    admin = UserFactory.create(is_staff=True, role=UserRoles.ADMIN)
+    position = PositionFactory.create()
+    url = reverse("positions-test-templates", args=[position.id])
+    api_client.force_authenticate(user=admin)
+
+    from positions.views.position import PositionViewSet
+
+    monkeypatch.setattr(
+        PositionViewSet, "_safe_assignments_queryset", lambda _position: None
+    )
+
+    res = api_client.get(url)
+
+    assert res.status_code == 503
+    assert "Run migrations for the positions app" in res.data["detail"]
+
+
+def test_set_position_test_templates_returns_503_when_table_missing(
+    api_client, monkeypatch
+):
+    admin = UserFactory.create(is_staff=True, role=UserRoles.ADMIN)
+    position = PositionFactory.create()
+    template = TemplateFactory.create(name="Driver Skills")
+    url = reverse("positions-test-templates", args=[position.id])
+    api_client.force_authenticate(user=admin)
+
+    from positions.models import PositionTestTemplateAssignment
+
+    class _FailingQuerySet:
+        @staticmethod
+        def delete():
+            raise ProgrammingError("relation does not exist")
+
+    class _FailingManager:
+        @staticmethod
+        def filter(*args, **kwargs):
+            return _FailingQuerySet()
+
+    monkeypatch.setattr(PositionTestTemplateAssignment, "objects", _FailingManager())
+
+    res = api_client.put(
+        url,
+        {"assignments": [{"template_id": template.id, "order": 0}]},
+        format="json",
+    )
+
+    assert res.status_code == 503
+    assert "Run migrations for the positions app" in res.data["detail"]

--- a/apps/backend/farid_tests/integrations/test_user_admin_roles.py
+++ b/apps/backend/farid_tests/integrations/test_user_admin_roles.py
@@ -1,0 +1,61 @@
+import pytest
+from django.urls import reverse
+
+from farid_tests.factories.users import UserFactory
+from users.models import User, UserRoles
+
+pytestmark = pytest.mark.django_db
+
+
+def test_users_admin_can_create_user_and_set_role(api_client):
+    admin = UserFactory.create(role=UserRoles.ADMIN, is_staff=True)
+    api_client.force_authenticate(user=admin)
+    url = reverse("users-list")
+
+    res = api_client.post(
+        url,
+        {
+            "email": "new.manager@example.com",
+            "password": "Passw0rd!23",
+            "first_name": "New",
+            "last_name": "Manager",
+            "role": UserRoles.MANAGER,
+            "is_active": True,
+        },
+        format="json",
+    )
+
+    assert res.status_code == 201
+    created = User.objects.get(email="new.manager@example.com")
+    assert created.role == UserRoles.MANAGER
+    assert created.is_active is True
+
+
+def test_users_non_admin_cannot_access_admin_user_management(api_client):
+    hr = UserFactory.create(role=UserRoles.HR, is_staff=True)
+    api_client.force_authenticate(user=hr)
+    url = reverse("users-list")
+
+    res = api_client.get(url)
+
+    assert res.status_code == 403
+
+
+def test_users_admin_can_activate_and_deactivate_user(api_client):
+    admin = UserFactory.create(role=UserRoles.ADMIN, is_staff=True)
+    target = UserFactory.create(role=UserRoles.MANAGER, is_active=True)
+    api_client.force_authenticate(user=admin)
+
+    deactivate_url = reverse("users-deactivate", args=[target.id])
+    deactivate_res = api_client.post(deactivate_url, format="json")
+    assert deactivate_res.status_code == 200
+
+    target.refresh_from_db()
+    assert target.is_active is False
+
+    activate_url = reverse("users-activate", args=[target.id])
+    activate_res = api_client.post(activate_url, format="json")
+    assert activate_res.status_code == 200
+
+    target.refresh_from_db()
+    assert target.is_active is True

--- a/apps/backend/farid_tests/units/test_candidate_serializer.py
+++ b/apps/backend/farid_tests/units/test_candidate_serializer.py
@@ -3,7 +3,7 @@ import pytest
 from django.db import IntegrityError
 
 from candidates.models import Candidate
-from users.models import User
+from users.models import User, UserRoles
 
 # Update this import to your actual serializer path:
 from candidates.serializers import CandidateSerializer
@@ -31,6 +31,7 @@ def test_candidate_serializer_creates_user_and_candidate():
 
     assert isinstance(candidate, Candidate)
     assert candidate.user.email == "jean.dupont@example.com"
+    assert candidate.user.role == UserRoles.CANDIDATE
     assert User.objects.filter(email="jean.dupont@example.com").exists()
 
 

--- a/apps/backend/positions/migrations/0002_positiontesttemplateassignment.py
+++ b/apps/backend/positions/migrations/0002_positiontesttemplateassignment.py
@@ -1,0 +1,71 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0001_initial"),
+        (
+            "templates_grid",
+            "0004_template_difficulty_template_duration_minutes_and_more",
+        ),
+        ("positions", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PositionTestTemplateAssignment",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("order", models.PositiveIntegerField(default=0)),
+                (
+                    "manager",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="managed_template_assignments",
+                        to="users.user",
+                    ),
+                ),
+                (
+                    "position",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="test_template_assignments",
+                        to="positions.position",
+                    ),
+                ),
+                (
+                    "template",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="position_assignments",
+                        to="templates_grid.template",
+                    ),
+                ),
+            ],
+            options={
+                "indexes": [
+                    models.Index(
+                        fields=["position", "order"], name="positions_po_57c7f0_idx"
+                    ),
+                    models.Index(fields=["manager"], name="positions_ma_38c84f_idx"),
+                ],
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("position", "template"),
+                        name="uniq_position_template_assignment",
+                    )
+                ],
+            },
+        ),
+    ]

--- a/apps/backend/positions/models/__init__.py
+++ b/apps/backend/positions/models/__init__.py
@@ -1,3 +1,6 @@
 from .position import Position as Position
+from .position_test_template_assignment import (
+    PositionTestTemplateAssignment as PositionTestTemplateAssignment,
+)
 
-__all__ = ["Position"]
+__all__ = ["Position", "PositionTestTemplateAssignment"]

--- a/apps/backend/positions/models/position_test_template_assignment.py
+++ b/apps/backend/positions/models/position_test_template_assignment.py
@@ -1,0 +1,45 @@
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from users.models import UserRoles
+
+
+class PositionTestTemplateAssignment(models.Model):
+    position = models.ForeignKey(
+        "positions.Position",
+        on_delete=models.CASCADE,
+        related_name="test_template_assignments",
+    )
+    template = models.ForeignKey(
+        "templates_grid.Template",
+        on_delete=models.PROTECT,
+        related_name="position_assignments",
+    )
+    manager = models.ForeignKey(
+        "users.User",
+        null=True,
+        blank=True,
+        on_delete=models.PROTECT,
+        related_name="managed_template_assignments",
+    )
+    order = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["position", "template"],
+                name="uniq_position_template_assignment",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["position", "order"]),
+            models.Index(fields=["manager"]),
+        ]
+
+    def clean(self):
+        super().clean()
+        if self.manager and self.manager.role != UserRoles.MANAGER:
+            raise ValidationError({"manager": "Assigned user must have manager role."})
+
+    def __str__(self) -> str:
+        return f"Position {self.position_id} -> Template {self.template_id}"

--- a/apps/backend/positions/serializers/__init__.py
+++ b/apps/backend/positions/serializers/__init__.py
@@ -1,4 +1,15 @@
 from .position import PositionSerializer as PositionSerializer
+from .position import (
+    PositionTemplateAssignmentBulkSerializer as PositionTemplateAssignmentBulkSerializer,
+)
+from .position import (
+    PositionTemplateAssignmentSerializer as PositionTemplateAssignmentSerializer,
+)
 from .position import PublicPositionSerializer as PublicPositionSerializer
 
-__all__ = ["PositionSerializer", "PublicPositionSerializer"]
+__all__ = [
+    "PositionSerializer",
+    "PublicPositionSerializer",
+    "PositionTemplateAssignmentSerializer",
+    "PositionTemplateAssignmentBulkSerializer",
+]

--- a/apps/backend/positions/serializers/position.py
+++ b/apps/backend/positions/serializers/position.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
-from positions.models import Position
+from positions.models import Position, PositionTestTemplateAssignment
+from templates_grid.models import Template
+from users.models import User, UserRoles
 
 
 class PositionSerializer(serializers.ModelSerializer):
@@ -34,3 +36,53 @@ class PublicPositionSerializer(serializers.ModelSerializer):
             "salary",
             "created_at",
         ]
+
+
+class PositionTemplateAssignmentSerializer(serializers.ModelSerializer):
+    template_name = serializers.CharField(source="template.name", read_only=True)
+    manager_id = serializers.IntegerField(source="manager.id", read_only=True)
+    manager_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PositionTestTemplateAssignment
+        fields = [
+            "id",
+            "position",
+            "template",
+            "template_name",
+            "manager_id",
+            "manager_name",
+            "order",
+        ]
+        read_only_fields = ["id", "template_name", "manager_id", "manager_name"]
+
+    def get_manager_name(self, obj):
+        if not obj.manager:
+            return None
+        return obj.manager.full_name or obj.manager.email
+
+
+class PositionTemplateAssignmentInputSerializer(serializers.Serializer):
+    template_id = serializers.IntegerField()
+    manager_id = serializers.IntegerField(required=False, allow_null=True)
+    order = serializers.IntegerField(required=False, min_value=0)
+
+    def validate_template_id(self, value):
+        if not Template.objects.filter(id=value).exists():
+            raise serializers.ValidationError("Unknown template.")
+        return value
+
+    def validate_manager_id(self, value):
+        if value is None:
+            return value
+        try:
+            manager = User.objects.get(id=value)
+        except User.DoesNotExist:
+            raise serializers.ValidationError("Unknown manager.")
+        if manager.role != UserRoles.MANAGER:
+            raise serializers.ValidationError("Assigned user must have manager role.")
+        return value
+
+
+class PositionTemplateAssignmentBulkSerializer(serializers.Serializer):
+    assignments = PositionTemplateAssignmentInputSerializer(many=True)

--- a/apps/backend/positions/views/position.py
+++ b/apps/backend/positions/views/position.py
@@ -1,9 +1,22 @@
+from django.db import transaction
+from django.db.utils import OperationalError, ProgrammingError
 from positions.models import Position
-from positions.serializers import PositionSerializer, PublicPositionSerializer
+from positions.models import PositionTestTemplateAssignment
+from positions.serializers import (
+    PositionSerializer,
+    PositionTemplateAssignmentBulkSerializer,
+    PositionTemplateAssignmentSerializer,
+    PublicPositionSerializer,
+)
+from templates_grid.models import Template
 from rest_framework.permissions import AllowAny
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.decorators import action
+from rest_framework import status
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 from users.permissions import IsHrAdminOrDirector
+from users.models import User
 
 
 class PositionViewSet(ModelViewSet):
@@ -14,10 +27,96 @@ class PositionViewSet(ModelViewSet):
         if self.action in ["list", "retrieve"]:
             return [AllowAny()]
 
-        if self.action in ["create", "update", "partial_update", "destroy"]:
+        if self.action in [
+            "create",
+            "update",
+            "partial_update",
+            "destroy",
+            "test_templates",
+            "set_test_templates",
+        ]:
             return [IsAuthenticated(), IsHrAdminOrDirector()]
 
         return [IsAuthenticated()]
+
+    @staticmethod
+    def _safe_assignments_queryset(position):
+        try:
+            return (
+                PositionTestTemplateAssignment.objects.select_related(
+                    "template", "manager"
+                )
+                .filter(position=position)
+                .order_by("order", "id")
+            )
+        except (ProgrammingError, OperationalError):
+            return None
+
+    @action(detail=True, methods=["get"], url_path="test-templates")
+    def test_templates(self, request, pk=None):
+        position = self.get_object()
+        queryset = self._safe_assignments_queryset(position)
+        if queryset is None:
+            return Response(
+                {
+                    "detail": (
+                        "Position test-template assignments are unavailable. "
+                        "Run migrations for the positions app."
+                    )
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        serializer = PositionTemplateAssignmentSerializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @test_templates.mapping.put
+    @transaction.atomic
+    def set_test_templates(self, request, pk=None):
+        position = self.get_object()
+        serializer = PositionTemplateAssignmentBulkSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            PositionTestTemplateAssignment.objects.filter(position=position).delete()
+        except (ProgrammingError, OperationalError):
+            return Response(
+                {
+                    "detail": (
+                        "Position test-template assignments are unavailable. "
+                        "Run migrations for the positions app."
+                    )
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        assignments = serializer.validated_data["assignments"]
+        for index, item in enumerate(assignments):
+            manager = None
+            manager_id = item.get("manager_id")
+            if manager_id is not None:
+                manager = User.objects.get(id=manager_id)
+
+            PositionTestTemplateAssignment.objects.create(
+                position=position,
+                template=Template.objects.get(id=item["template_id"]),
+                manager=manager,
+                order=item.get("order", index),
+            )
+
+        queryset = self._safe_assignments_queryset(position)
+        if queryset is None:
+            return Response(
+                {
+                    "detail": (
+                        "Position test-template assignments are unavailable. "
+                        "Run migrations for the positions app."
+                    )
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        output = PositionTemplateAssignmentSerializer(queryset, many=True)
+        return Response(output.data, status=status.HTTP_200_OK)
 
 
 class PublicPositionViewSet(ReadOnlyModelViewSet):

--- a/apps/backend/recruitment/views/job_application_view.py
+++ b/apps/backend/recruitment/views/job_application_view.py
@@ -1,6 +1,11 @@
 from rest_framework.viewsets import ModelViewSet
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.exceptions import PermissionDenied
+
 from recruitment.models.job_application import JobApplication
 from recruitment.serializers import JobApplicationSerializer
+from users.models import UserRoles
+from users.permissions import IsHrAdminOrDirector
 
 
 class JobApplicationViewSet(ModelViewSet):
@@ -10,3 +15,37 @@ class JobApplicationViewSet(ModelViewSet):
         .order_by("id")
     )
     serializer_class = JobApplicationSerializer
+
+    def get_permissions(self):
+        if self.action in ["update", "partial_update", "destroy"]:
+            return [IsAuthenticated(), IsHrAdminOrDirector()]
+        return [IsAuthenticated()]
+
+    def get_queryset(self):
+        queryset = self.queryset
+        user = self.request.user
+
+        if user.role in {UserRoles.HR, UserRoles.ADMIN, UserRoles.DIRECTOR}:
+            return queryset
+
+        if user.role == UserRoles.CANDIDATE and hasattr(user, "candidate_profile"):
+            return queryset.filter(candidate=user.candidate_profile)
+
+        return queryset.none()
+
+    def perform_create(self, serializer):
+        user = self.request.user
+
+        if user.role in {UserRoles.HR, UserRoles.ADMIN, UserRoles.DIRECTOR}:
+            serializer.save()
+            return
+
+        if user.role != UserRoles.CANDIDATE or not hasattr(user, "candidate_profile"):
+            raise PermissionDenied("You are not allowed to create job applications.")
+
+        if serializer.validated_data["candidate"].id != user.candidate_profile.id:
+            raise PermissionDenied(
+                "You can only apply using your own candidate profile."
+            )
+
+        serializer.save()

--- a/apps/backend/users/models/roles.py
+++ b/apps/backend/users/models/roles.py
@@ -6,4 +6,6 @@ class UserRoles(models.TextChoices):
     HR = "hr", "Human Resources"
     MANAGER = "manager", "Manager"
     DIRECTOR = "director", "Director"
+    DRIVER = "driver", "Driver"
+    CANDIDATE = "candidate", "Candidate"
     EMPLOYEE = "employee", "Employee"

--- a/apps/backend/users/permissions/__init__.py
+++ b/apps/backend/users/permissions/__init__.py
@@ -1,3 +1,6 @@
 from .roles import IsHrAdminOrDirector as IsHrAdminOrDirector
+from .roles import IsManager as IsManager
+from .roles import IsCandidate as IsCandidate
+from .roles import IsAdmin as IsAdmin
 
-__all__ = ["IsHrAdminOrDirector"]
+__all__ = ["IsHrAdminOrDirector", "IsManager", "IsCandidate", "IsAdmin"]

--- a/apps/backend/users/permissions/roles.py
+++ b/apps/backend/users/permissions/roles.py
@@ -15,3 +15,15 @@ class HasAnyRole(BasePermission):
 
 class IsHrAdminOrDirector(HasAnyRole):
     allowed_roles = {UserRoles.HR, UserRoles.ADMIN, UserRoles.DIRECTOR}
+
+
+class IsManager(HasAnyRole):
+    allowed_roles = {UserRoles.MANAGER}
+
+
+class IsCandidate(HasAnyRole):
+    allowed_roles = {UserRoles.CANDIDATE}
+
+
+class IsAdmin(HasAnyRole):
+    allowed_roles = {UserRoles.ADMIN}

--- a/apps/backend/users/serializers/user.py
+++ b/apps/backend/users/serializers/user.py
@@ -9,6 +9,7 @@ class UserSerializer(serializers.ModelSerializer):
             "id",
             "email",
             "role",
+            "is_active",
             "password",
             "first_name",
             "last_name",
@@ -18,7 +19,10 @@ class UserSerializer(serializers.ModelSerializer):
         }
 
     def validate_email(self, value):
-        if User.objects.filter(email=value).exists():
+        queryset = User.objects.filter(email=value)
+        if self.instance:
+            queryset = queryset.exclude(id=self.instance.id)
+        if queryset.exists():
             raise serializers.ValidationError("Email already exists.")
         return value
 
@@ -26,3 +30,12 @@ class UserSerializer(serializers.ModelSerializer):
         password = validated_data.pop("password")
         user = User.objects.create_user(password=password, **validated_data)
         return user
+
+    def update(self, instance, validated_data):
+        password = validated_data.pop("password", None)
+        for key, value in validated_data.items():
+            setattr(instance, key, value)
+        if password:
+            instance.set_password(password)
+        instance.save()
+        return instance

--- a/apps/backend/users/views/user.py
+++ b/apps/backend/users/views/user.py
@@ -2,14 +2,17 @@ from rest_framework.viewsets import ModelViewSet
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
 
 from users.models import User
 from users.serializers import UserSerializer
+from users.permissions import IsAdmin
 
 
 class UserViewSet(ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    permission_classes = [IsAuthenticated, IsAdmin]
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
@@ -44,3 +47,10 @@ class UserViewSet(ModelViewSet):
         user.is_active = False
         user.save()
         return Response({"status": "user deactivated"}, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=["post"], url_path="activate")
+    def activate(self, request, pk=None):
+        user = self.get_object()
+        user.is_active = True
+        user.save()
+        return Response({"status": "user activated"}, status=status.HTTP_200_OK)

--- a/apps/candidate/src/app/core/auth/services/auth.service.spec.ts
+++ b/apps/candidate/src/app/core/auth/services/auth.service.spec.ts
@@ -19,6 +19,7 @@ describe('AuthService (candidate)', () => {
   const loginUrl = `${environment.apiBaseUrl}/api/auth/login/`;
   const refreshUrl = `${environment.apiBaseUrl}/api/auth/refresh/`;
   const candidatesUrl = `${environment.apiBaseUrl}/api/candidates/`;
+  const candidateMeUrl = `${environment.apiBaseUrl}/api/candidates/me/`;
 
   beforeEach(() => {
     localStorage.clear();
@@ -48,7 +49,7 @@ describe('AuthService (candidate)', () => {
     localStorage.clear();
   });
 
-  it('signIn stores tokens and resolves candidate profile from candidates API', () => {
+  it('signIn stores tokens and resolves candidate profile from /candidates/me/', () => {
     let candidateId: number | null = null;
 
     service
@@ -70,22 +71,48 @@ describe('AuthService (candidate)', () => {
       },
     });
 
-    const candidatesRequest = httpMock.expectOne(candidatesUrl);
-    expect(candidatesRequest.request.method).toBe('GET');
-    candidatesRequest.flush([
-      {
-        id: 44,
-        user: {
-          email: 'john@example.com',
-          first_name: 'John',
-          last_name: 'Doe',
-          phone: '+330000000',
-        },
+    const meRequest = httpMock.expectOne(candidateMeUrl);
+    expect(meRequest.request.method).toBe('GET');
+    meRequest.flush({
+      id: 44,
+      user: {
+        email: 'john@example.com',
+        first_name: 'John',
+        last_name: 'Doe',
+        phone: '+330000000',
       },
-    ]);
+    });
 
     expect(candidateId).toBe(44);
     expect(tokenStorageSpy.saveTokens).toHaveBeenCalledWith('access-token', 'refresh-token');
+  });
+
+  it('signIn returns explicit message when user is not a candidate', () => {
+    let actualError: string | null = null;
+
+    service.signIn({ email: 'hr@example.com', password: 'Secret123' }).subscribe({
+      next: () => fail('Expected error'),
+      error: (errorMessage: string) => {
+        actualError = errorMessage;
+      },
+    });
+
+    const loginRequest = httpMock.expectOne(loginUrl);
+    loginRequest.flush({
+      access: 'access-token',
+      refresh: 'refresh-token',
+      user: {
+        id: 8,
+        email: 'hr@example.com',
+        first_name: 'HR',
+        last_name: 'User',
+      },
+    });
+
+    const meRequest = httpMock.expectOne(candidateMeUrl);
+    meRequest.flush({}, { status: 403, statusText: 'Forbidden' });
+
+    expect(actualError).toBe('Your account does not have candidate access for this application.');
   });
 
   it('maps nested backend validation errors to user-friendly message', () => {

--- a/apps/candidate/src/app/core/auth/services/auth.service.ts
+++ b/apps/candidate/src/app/core/auth/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import { Observable, catchError, map, of, switchMap, throwError } from 'rxjs';
+import { Observable, catchError, map, switchMap, throwError } from 'rxjs';
 
 import { environment } from '@env/environment';
 
@@ -48,6 +48,16 @@ interface CandidateDto {
   };
 }
 
+interface CandidateProfileDto {
+  id: number;
+  user: {
+    email: string;
+    first_name: string;
+    last_name: string;
+    phone?: string;
+  };
+}
+
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private readonly http = inject(HttpClient);
@@ -57,6 +67,7 @@ export class AuthService {
 
   private readonly authBaseUrl = `${environment.apiBaseUrl}/api/auth`;
   private readonly candidatesUrl = `${environment.apiBaseUrl}/api/candidates/`;
+  private readonly candidateMeUrl = `${environment.apiBaseUrl}/api/candidates/me/`;
 
   isAuthenticated(): boolean {
     return this.tokenStorage.isAuthenticated();
@@ -72,11 +83,7 @@ export class AuthService {
         switchMap((response) => {
           this.persistTokens(response.access, response.refresh);
 
-          return this.resolveCandidateProfile(payload.email, {
-            firstName: response.user?.first_name ?? '',
-            lastName: response.user?.last_name ?? '',
-            phone: '',
-          });
+          return this.resolveCandidateProfile();
         }),
         map((candidate) => {
           this.saveAuthenticatedCandidate(candidate);
@@ -149,43 +156,26 @@ export class AuthService {
     });
   }
 
-  private resolveCandidateProfile(
-    email: string,
-    fallback: { firstName: string; lastName: string; phone: string },
-  ): Observable<AuthenticatedCandidate> {
-    return this.http.get<CandidateDto[]>(this.candidatesUrl).pipe(
-      map((candidates) => {
-        const candidate = candidates.find(
-          (item) => item.user.email.toLowerCase() === email.toLowerCase(),
-        );
-
-        if (!candidate) {
-          return {
-            candidateId: Date.now(),
-            email,
-            firstName: fallback.firstName,
-            lastName: fallback.lastName,
-            phone: fallback.phone,
-          };
+  private resolveCandidateProfile(): Observable<AuthenticatedCandidate> {
+    return this.http.get<CandidateProfileDto>(this.candidateMeUrl).pipe(
+      map((candidate) => ({
+        candidateId: candidate.id,
+        email: candidate.user.email,
+        firstName: candidate.user.first_name,
+        lastName: candidate.user.last_name,
+        phone: candidate.user.phone ?? '',
+      })),
+      catchError((error: unknown) => {
+        if (error instanceof HttpErrorResponse && error.status === 403) {
+          return throwError(
+            () => 'Your account does not have candidate access for this application.',
+          );
         }
-
-        return {
-          candidateId: candidate.id,
-          email: candidate.user.email,
-          firstName: candidate.user.first_name,
-          lastName: candidate.user.last_name,
-          phone: candidate.user.phone ?? '',
-        };
+        if (error instanceof HttpErrorResponse && error.status === 404) {
+          return throwError(() => 'Candidate profile not found. Please contact support.');
+        }
+        return throwError(() => 'Unable to load candidate profile.');
       }),
-      catchError(() =>
-        of({
-          candidateId: Date.now(),
-          email,
-          firstName: fallback.firstName,
-          lastName: fallback.lastName,
-          phone: fallback.phone,
-        }),
-      ),
     );
   }
 
@@ -194,6 +184,10 @@ export class AuthService {
   }
 
   private mapAuthError(error: unknown): Observable<never> {
+    if (typeof error === 'string') {
+      return throwError(() => error);
+    }
+
     if (!(error instanceof HttpErrorResponse)) {
       return throwError(() => 'Unexpected authentication error.');
     }

--- a/apps/frontend/src/app/app.html
+++ b/apps/frontend/src/app/app.html
@@ -1,27 +1,22 @@
 <div class="min-h-screen bg-slate-950 text-slate-100">
-  <div class="fixed inset-x-0 top-0 z-50">
-    <app-top-bar
-      title="Recruitment Overview"
-      subtitle="Fleet Management Hub"
-      [notificationCount]="1"
-      [user]="{ fullName: 'Farid' }"
-    />
-  </div>
+  @if (showNavigationChrome()) {
+    <div class="fixed inset-x-0 top-0 z-50">
+      <app-top-bar
+        title="Recruitment Overview"
+        subtitle="Fleet Management Hub"
+        [notificationCount]="1"
+        [user]="{ fullName: 'Farid' }"
+      />
+    </div>
+  }
 
-  <main class="px-0 pt-[72px] pb-[72px]">
+  <main class="px-0" [class.pt-[72px]]="showNavigationChrome()" [class.pb-[72px]]="showNavigationChrome()">
     <router-outlet />
   </main>
 
-  <div class="fixed inset-x-0 bottom-0 z-50">
-    <app-menu-bar
-      [items]="[
-        { label: 'Dashboard', icon: '📊', route: '/dashboard' },
-        { label: 'Candidates', icon: '👥', route: '/candidates' },
-        { label: 'Tests', icon: '🧪', route: '/tests' },
-        { label: 'Templates', icon: '📐', route: '/templates' },
-        { label: 'Positions', icon: '📋', route: '/positions' },
-        { label: 'Pools', icon: '🗂️', route: '/pools' },
-      ]"
-    />
-  </div>
+  @if (showNavigationChrome()) {
+    <div class="fixed inset-x-0 bottom-0 z-50">
+      <app-menu-bar [items]="menuItems()" />
+    </div>
+  }
 </div>

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -45,6 +45,20 @@ export const routes: Routes = [
     canActivate: [AuthGuard, RoleGuard],
     data: { roles: ['hr', 'admin', 'director', 'manager'] },
   },
+  {
+    path: 'tests',
+    loadChildren: () =>
+      import('src/app/features/tests/tests.routes').then((m) => m.TESTS_ROUTES),
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['hr', 'admin', 'director', 'manager'] },
+  },
+  {
+    path: 'roles',
+    loadComponent: () =>
+      import('./features/roles/pages/roles-admin.page').then((m) => m.RolesAdminPage),
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['admin'] },
+  },
 
   { path: '', pathMatch: 'full', redirectTo: 'dashboard' },
   { path: '**', redirectTo: 'dashboard' },

--- a/apps/frontend/src/app/app.spec.ts
+++ b/apps/frontend/src/app/app.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { provideRouter } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 
 import { App } from './app';
 
@@ -29,5 +29,21 @@ describe('App', () => {
 
     expect(topBarContainer).toBeTruthy();
     expect(bottomBarContainer).toBeTruthy();
+  });
+
+  it('hides top and bottom bars on /login route', async () => {
+    const fixture = TestBed.createComponent(App);
+    const router = TestBed.inject(Router);
+
+    await router.navigateByUrl('/login');
+    fixture.detectChanges();
+
+    const topBarContainer = fixture.debugElement.query(By.css('div.fixed.inset-x-0.top-0'));
+    const bottomBarContainer = fixture.debugElement.query(
+      By.css('div.fixed.inset-x-0.bottom-0'),
+    );
+
+    expect(topBarContainer).toBeFalsy();
+    expect(bottomBarContainer).toBeFalsy();
   });
 });

--- a/apps/frontend/src/app/app.ts
+++ b/apps/frontend/src/app/app.ts
@@ -1,14 +1,78 @@
-import { Component, signal } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Component, computed, inject, signal } from '@angular/core';
+import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { MenuBarComponent } from './layout/menu-bar/menu-bar';
 import { TopBarComponent } from './layout/top-bar/top-bar';
+import { AuthSessionService } from './core/auth/services/auth-session.service';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { filter } from 'rxjs';
 
 @Component({
   selector: 'app-root',
   imports: [RouterOutlet, TopBarComponent, MenuBarComponent],
   templateUrl: './app.html',
-  styleUrl: './app.scss'
+  styleUrl: './app.scss',
 })
 export class App {
+  private readonly session = inject(AuthSessionService);
+  private readonly router = inject(Router);
   protected readonly title = signal('frontend');
+  readonly me = signal<{ role?: string | null } | null>(null);
+  readonly currentUrl = signal(this.router.url);
+  readonly showNavigationChrome = computed(() => !this.currentUrl().startsWith('/login'));
+
+  readonly menuItems = computed(() => {
+    const role = this.me()?.role;
+    const common = [{ label: 'Dashboard', icon: '📊', route: '/dashboard' }];
+
+    if (role === 'hr' || role === 'director') {
+      return [
+        ...common,
+        { label: 'Candidates', icon: '👥', route: '/candidates' },
+        { label: 'Tests', icon: '🧪', route: '/tests' },
+        { label: 'Templates', icon: '📐', route: '/templates' },
+        { label: 'Positions', icon: '📋', route: '/positions' },
+        { label: 'Pools', icon: '🗂️', route: '/pools' },
+      ];
+    }
+
+    if (role === 'admin') {
+      return [
+        ...common,
+        { label: 'Candidates', icon: '👥', route: '/candidates' },
+        { label: 'Tests', icon: '🧪', route: '/tests' },
+        { label: 'Templates', icon: '📐', route: '/templates' },
+        { label: 'Positions', icon: '📋', route: '/positions' },
+        { label: 'Pools', icon: '🗂️', route: '/pools' },
+        { label: 'Roles', icon: '🛡️', route: '/roles' },
+      ];
+    }
+
+    if (role === 'manager') {
+      return [
+        ...common,
+        { label: 'Tests', icon: '🧪', route: '/tests' },
+        { label: 'Positions', icon: '📋', route: '/positions' },
+      ];
+    }
+
+    if (role === 'candidate' || role === 'employee') {
+      return [...common];
+    }
+
+    return [...common];
+  });
+
+  constructor() {
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntilDestroyed(),
+      )
+      .subscribe((event) => this.currentUrl.set(event.urlAfterRedirects));
+
+    this.session
+      .loadMeOnce()
+      .pipe(takeUntilDestroyed())
+      .subscribe((me) => this.me.set(me));
+  }
 }

--- a/apps/frontend/src/app/core/auth/interceptors/auth.interceptor.spec.ts
+++ b/apps/frontend/src/app/core/auth/interceptors/auth.interceptor.spec.ts
@@ -103,7 +103,7 @@ describe('authInterceptor (HttpInterceptorFn)', () => {
     );
 
     let responseBody: { ok: boolean } | undefined;
-    http.get('/api/protected').subscribe((res) => (responseBody = res));
+    http.get<{ ok: boolean }>('/api/protected').subscribe((res) => (responseBody = res));
 
     // First attempt (with OLD token)
     const firstReq = httpMock.expectOne('/api/protected');

--- a/apps/frontend/src/app/core/auth/models/auth.models.ts
+++ b/apps/frontend/src/app/core/auth/models/auth.models.ts
@@ -1,7 +1,4 @@
-export type LoginProfile = 'driver' | 'manager' | 'hr';
-
 export interface LoginRequest {
-  profile: LoginProfile;
   email: string;
   password: string;
 }

--- a/apps/frontend/src/app/core/auth/services/auth.service.spec.ts
+++ b/apps/frontend/src/app/core/auth/services/auth.service.spec.ts
@@ -25,9 +25,8 @@ describe('AuthService', () => {
     httpMock.verify();
   });
 
-  it('login should POST /login/ with LoginRequest payload and return LoginResponse', () => {
+  it('login should POST /login/ with email/password and return LoginResponse', () => {
     const payload: LoginRequest = {
-      profile: 'driver',
       email: 'test@test.com',
       password: 'password123',
     };
@@ -43,7 +42,10 @@ describe('AuthService', () => {
 
     const req = httpMock.expectOne(`${base}/login/`);
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual(payload);
+    expect(req.request.body).toEqual({
+      email: payload.email,
+      password: payload.password,
+    });
 
     req.flush(mockResponse);
   });

--- a/apps/frontend/src/app/core/auth/services/auth.service.ts
+++ b/apps/frontend/src/app/core/auth/services/auth.service.ts
@@ -11,7 +11,10 @@ export class AuthService {
   private readonly base = `${environment.apiBaseUrl}/api/auth`;
 
   login(payload: LoginRequest): Observable<LoginResponse> {
-    return this.http.post<LoginResponse>(`${this.base}/login/`, payload);
+    return this.http.post<LoginResponse>(`${this.base}/login/`, {
+      email: payload.email,
+      password: payload.password,
+    });
   }
 
   me(): Observable<MeResponse> {

--- a/apps/frontend/src/app/features/auth/pages/login.page.html
+++ b/apps/frontend/src/app/features/auth/pages/login.page.html
@@ -1,60 +1,108 @@
-<div class="min-h-screen flex items-center justify-center bg-slate-950 p-4">
-  <div class="w-full max-w-sm rounded-2xl bg-slate-900/60 border border-slate-700/50 shadow-xl p-6">
+<section class="h-screen overflow-hidden bg-[#05143a] px-4 py-6 text-slate-100 sm:px-6 sm:py-8">
+  <div class="mx-auto flex h-full w-full max-w-xl flex-col justify-center">
+    <header class="mb-6 text-center sm:mb-7">
+      <div class="inline-flex items-center gap-3 sm:gap-5">
+        <div class="inline-flex h-16 w-16 items-center justify-center rounded-2xl bg-[#3b82f6] shadow-[0_10px_30px_rgba(59,130,246,0.35)] sm:h-20 sm:w-20">
+          <svg
+            class="h-8 w-8 text-white sm:h-10 sm:w-10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.9"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="2.75" y="7" width="12.5" height="8.6" rx="0.8" />
+            <path d="M15.25 10h3.1l2.9 3.1v2.5h-6" />
+            <circle cx="8" cy="17.2" r="1.35" />
+            <circle cx="18" cy="17.2" r="1.35" />
+          </svg>
+        </div>
+        <h1 class="text-4xl font-black uppercase italic leading-none tracking-tight sm:text-5xl md:text-6xl">
+          <span class="text-slate-100">Fleet</span><span class="text-[#3b82f6]">Flow</span>
+        </h1>
+      </div>
+      <p class="mt-3 text-[11px] font-semibold uppercase tracking-[0.28em] text-slate-400 sm:text-[13px] sm:tracking-[0.32em]">
+        Logistics & Recruitment Portal
+      </p>
+    </header>
 
-    <!-- Header -->
-    <div class="text-center mb-6">
-      <h1 class="text-xl font-semibold text-white">FleetConnect HR</h1>
-      <p class="text-xs text-slate-400">Logistics & Recruitment Portal</p>
-    </div>
-
-    <!-- Profile selector -->
-    <div class="grid grid-cols-3 gap-2 mb-5">
-      @for (p of profiles; track p.key) {
-        <button
-          type="button"
-          class="rounded-lg border px-2 py-3 text-xs font-semibold transition text-white"
-          [class.border-sky-500]="selectedProfile() === p.key"
-          (click)="selectProfile(p.key)"
-        >
-          {{ p.label }}
-        </button>
+    <article class="rounded-[28px] border border-slate-700/40 bg-[#1a2948] px-5 py-6 shadow-[0_24px_45px_rgba(0,0,0,0.42)] sm:px-8 sm:py-8">
+      @if (errorMessage()) {
+        <div class="mb-4 rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm text-red-200">
+          {{ errorMessage() }}
+        </div>
       }
+
+      <form [formGroup]="form" (ngSubmit)="submit()" class="space-y-6 sm:space-y-7">
+        <div class="space-y-3">
+          <label class="block text-[14px] font-bold uppercase tracking-[0.12em] text-slate-400" for="login-email">
+            Email address
+          </label>
+          <div class="flex h-16 items-center gap-3 rounded-2xl border border-slate-700/60 bg-[#121f3b] px-4 sm:h-[70px] sm:gap-4 sm:px-5">
+            <svg class="h-6 w-6 text-slate-400 sm:h-7 sm:w-7" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+              <path d="M3 6.75h18v10.5H3z" />
+              <path d="m4 8 8 6 8-6" />
+            </svg>
+            <input
+              id="login-email"
+              formControlName="email"
+              type="email"
+              placeholder="name@fleetflow.com"
+              class="w-full bg-transparent text-base text-slate-300 placeholder:text-slate-400/80 focus:outline-none sm:text-lg"
+            />
+          </div>
+        </div>
+
+        <div class="space-y-3">
+          <div class="flex items-center justify-between">
+            <label class="text-[13px] font-bold uppercase tracking-[0.12em] text-slate-400 sm:text-[14px]" for="login-password">Password</label>
+            <a routerLink="/support" class="text-[12px] font-bold uppercase tracking-[0.12em] text-[#3b82f6] hover:text-blue-300 sm:text-[13px]">
+              Forgot password?
+            </a>
+          </div>
+          <div class="flex h-16 items-center gap-3 rounded-2xl border border-slate-700/60 bg-[#121f3b] px-4 sm:h-[70px] sm:gap-4 sm:px-5">
+            <svg class="h-6 w-6 text-slate-400 sm:h-7 sm:w-7" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+              <rect x="4.5" y="10" width="15" height="10" rx="1.5" />
+              <path d="M8 10V7.5a4 4 0 1 1 8 0V10" />
+              <circle cx="12" cy="15" r="1" />
+            </svg>
+            <input
+              id="login-password"
+              formControlName="password"
+              type="password"
+              placeholder="••••••••"
+              class="w-full bg-transparent text-base tracking-[0.18em] text-slate-300 placeholder:text-slate-400/90 focus:outline-none sm:text-lg"
+            />
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          class="h-16 w-full rounded-2xl bg-[#3b82f6] text-xl font-bold uppercase tracking-[0.08em] text-slate-100 shadow-[0_0_24px_rgba(59,130,246,0.45)] transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60 sm:h-[72px] sm:text-2xl"
+          [disabled]="loading()"
+        >
+          {{ loading() ? 'Logging in…' : 'Log in ↪' }}
+        </button>
+
+        <label class="sr-only">
+          <input type="checkbox" formControlName="rememberMe" />
+        </label>
+      </form>
+    </article>
+
+    <div class="mt-8 text-center text-base text-slate-400 sm:mt-10 sm:text-[18px]">
+      Don’t have an account?
+      <a routerLink="/support" class="font-semibold text-slate-100 underline decoration-[#3b82f6] decoration-2 underline-offset-4">
+        Request Access
+      </a>
     </div>
 
-    <app-ui-alert [message]="errorMessage()"></app-ui-alert>
-
-    <form [formGroup]="form" (ngSubmit)="submit()" class="space-y-4">
-
-      <app-ui-text-input
-        formControlName="email"
-        [label]="emailLabel()"
-        placeholder="Enter your credentials">
-      </app-ui-text-input>
-
-      <app-ui-password-input
-        formControlName="password"
-        label="Password"
-        placeholder="••••••••">
-      </app-ui-password-input>
-
-      <label class="flex items-center gap-2 text-xs text-slate-300">
-        <input type="checkbox" formControlName="rememberMe" />
-        Remember me
-      </label>
-
-      <app-ui-button-primary
-        type="submit"
-        variant="primary"
-        [loading]="loading()"
-        block>
-        Sign In
-      </app-ui-button-primary>
-
-    </form>
-
-    <div class="mt-6 text-center text-xs text-slate-400">
-      <a routerLink="/support" class="text-sky-400">Contact Dispatch</a>
+    <div class="mt-6 border-t border-slate-700/40 pt-5 text-center sm:mt-8 sm:pt-7">
+      <p class="mx-auto inline-flex rounded-full border border-slate-700/50 px-6 py-1.5 font-mono text-[11px] tracking-[0.16em] text-slate-500 uppercase sm:px-8 sm:py-2 sm:text-[13px]">
+        V 0.0.0 "KINETIC" // SYSTEM_ACTIVE
+      </p>
     </div>
-
   </div>
-</div>
+</section>

--- a/apps/frontend/src/app/features/auth/pages/login.page.spec.ts
+++ b/apps/frontend/src/app/features/auth/pages/login.page.spec.ts
@@ -42,21 +42,6 @@ describe('LoginPage', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should default to driver profile and correct email label', () => {
-    expect(component.selectedProfile()).toBe('driver');
-    expect(component.emailLabel()).toBe('Driver Email');
-  });
-
-  it('selectProfile should update profile and clear errorMessage', () => {
-    component.errorMessage.set('Some error');
-
-    component.selectProfile('hr');
-
-    expect(component.selectedProfile()).toBe('hr');
-    expect(component.errorMessage()).toBeNull();
-    expect(component.emailLabel()).toBe('Email');
-  });
-
   it('submit should mark form touched and do nothing if form invalid', () => {
     const markSpy = spyOn(component.form, 'markAllAsTouched');
 
@@ -86,11 +71,10 @@ describe('LoginPage', () => {
     expect(authServiceSpy.login).not.toHaveBeenCalled();
   });
 
-  it('submit should call auth.login with selected profile and credentials', () => {
+  it('submit should call auth.login with credentials', () => {
     const mockRes: LoginResponse = { access: 'ACCESS_TOKEN', refresh: 'REFRESH_TOKEN' };
     authServiceSpy.login.and.returnValue(of(mockRes));
 
-    component.selectProfile('manager');
     component.form.setValue({
       email: 'manager@test.com',
       password: 'pwd',
@@ -100,7 +84,6 @@ describe('LoginPage', () => {
     component.submit();
 
     const expected: LoginRequest = {
-      profile: 'manager',
       email: 'manager@test.com',
       password: 'pwd',
     };

--- a/apps/frontend/src/app/features/auth/pages/login.page.ts
+++ b/apps/frontend/src/app/features/auth/pages/login.page.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormBuilder,
@@ -16,12 +10,6 @@ import { take } from 'rxjs/operators';
 
 import { AuthService } from '@auth/services/auth.service';
 import { TokenStorageService } from '@auth/services/token-storage.service';
-import { LoginProfile } from '@auth/models/auth.models';
-
-import { UiTextInputComponent } from '@lib-ui/text-input/text-input.component';
-import { UiPasswordInputComponent } from '@lib-ui/password-input/password-input.component';
-import { UiButtonPrimaryComponent } from '@lib-ui/button-primary/button-primary.component';
-import { UiAlertComponent } from '@lib-ui/alert/alert.component';
 
 @Component({
   standalone: true,
@@ -30,10 +18,6 @@ import { UiAlertComponent } from '@lib-ui/alert/alert.component';
     CommonModule,
     ReactiveFormsModule,
     RouterModule,
-    UiTextInputComponent,
-    UiPasswordInputComponent,
-    UiButtonPrimaryComponent,
-    UiAlertComponent,
   ],
   templateUrl: './login.page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -44,30 +28,14 @@ export class LoginPage {
   private readonly tokenStorage = inject(TokenStorageService);
   private readonly router = inject(Router);
 
-  readonly profiles: { key: LoginProfile; label: string }[] = [
-    { key: 'driver', label: 'DRIVER' },
-    { key: 'manager', label: 'MANAGER' },
-    { key: 'hr', label: 'HR/ADMIN' },
-  ];
-
-  readonly selectedProfile = signal<LoginProfile>('driver');
   readonly loading = signal(false);
   readonly errorMessage = signal<string | null>(null);
-
-  readonly emailLabel = computed(() =>
-    this.selectedProfile() === 'driver' ? 'Driver Email' : 'Email'
-  );
 
   readonly form = this.fb.nonNullable.group({
     email: ['', Validators.required],
     password: ['', Validators.required],
     rememberMe: [true],
   });
-
-  selectProfile(profile: LoginProfile): void {
-    this.selectedProfile.set(profile);
-    this.errorMessage.set(null);
-  }
 
   submit(): void {
     if (this.form.invalid || this.loading()) {
@@ -82,7 +50,6 @@ export class LoginPage {
 
     this.auth
       .login({
-        profile: this.selectedProfile(),
         email,
         password,
       })

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard.page.html
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard.page.html
@@ -1,14 +1,70 @@
-<div class="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center px-4">
-  <div class="max-w-xl w-full rounded-2xl bg-slate-900/60 border border-slate-800 p-6">
-    <h1 class="text-2xl font-semibold">Dashboard</h1>
-    <p class="text-slate-300 mt-2">✅ Vous êtes connecté.</p>
+<section class="min-h-screen bg-[#050c16] px-4 pb-24 pt-6 text-slate-100 sm:px-6">
+  <div class="mx-auto w-full max-w-6xl space-y-5">
+    <header class="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+      <h1 class="text-2xl font-semibold">{{ pageTitle() }}</h1>
+      <p class="mt-1 text-sm text-slate-400">{{ subtitle() }}</p>
+    </header>
 
-    <button
-      class="mt-6 rounded-xl border border-slate-800 bg-slate-950/60 px-4 py-2"
-      (click)="logout()"
-    >
-      Logout
-    </button>
+    <div class="grid gap-3 sm:grid-cols-3">
+      @for (card of statCards(); track card.label) {
+        <article
+          class="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"
+          [class.border-blue-500/40]="card.accent === 'blue'"
+          [class.border-cyan-500/40]="card.accent === 'cyan'"
+          [class.border-rose-500/40]="card.accent === 'rose'"
+          [class.border-amber-500/40]="card.accent === 'amber'"
+          [class.border-emerald-500/40]="card.accent === 'emerald'"
+          [class.border-violet-500/40]="card.accent === 'violet'"
+        >
+          <div class="text-[11px] uppercase tracking-[0.12em] text-slate-400">{{ card.label }}</div>
+          <div class="mt-1 text-4xl font-black">{{ card.value }}</div>
+        </article>
+      }
+    </div>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+      <h2 class="text-2xl font-semibold">Role dashboard preview</h2>
+      <p class="mt-1 text-sm text-slate-400">
+        This visual block is role-specific and mirrors your reference style.
+      </p>
+      <div class="mt-4 rounded-xl border border-dashed border-slate-700 bg-slate-950/50 p-4 text-sm text-slate-400">
+        TODO: wire real dashboard widgets (charts, candidate/test feeds, operational events) to backend APIs per role.
+      </div>
+    </section>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900/70 p-5">
+      <h2 class="text-2xl font-semibold">Quick access</h2>
+      <div class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        @for (item of quickAccess(); track item.label) {
+          <button
+            type="button"
+            class="rounded-xl border p-4 text-left transition"
+            [class.border-slate-700]="item.enabled"
+            [class.bg-slate-800/60]="item.enabled"
+            [class.hover:border-blue-500]="item.enabled"
+            [class.hover:bg-slate-800]="item.enabled"
+            [class.border-slate-800]="!item.enabled"
+            [class.bg-slate-900/60]="!item.enabled"
+            [class.opacity-60]="!item.enabled"
+            (click)="openQuickAccess(item)"
+          >
+            <div class="text-lg">{{ item.icon }}</div>
+            <div class="mt-1 text-sm font-semibold">{{ item.label }}</div>
+            @if (!item.enabled) {
+              <div class="mt-1 text-[10px] uppercase tracking-[0.12em] text-slate-500">Coming soon</div>
+            }
+          </button>
+        }
+      </div>
+    </section>
+
+    <div class="flex justify-end">
+      <button
+        class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-2 text-sm hover:bg-slate-800"
+        (click)="logout()"
+      >
+        Logout
+      </button>
+    </div>
   </div>
-</div>
-
+</section>

--- a/apps/frontend/src/app/features/dashboard/pages/dashboard.page.ts
+++ b/apps/frontend/src/app/features/dashboard/pages/dashboard.page.ts
@@ -1,7 +1,18 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { AuthSessionService } from '@auth/services/auth-session.service';
+import { take } from 'rxjs';
+import { AllowedRole } from '@auth/models/auth.models';
+
+type DashboardRole = AllowedRole | 'driver';
+
+interface QuickAccessItem {
+  label: string;
+  route: string | null;
+  icon: string;
+  enabled: boolean;
+}
 
 @Component({
   standalone: true,
@@ -12,6 +23,128 @@ import { AuthSessionService } from '@auth/services/auth-session.service';
 export class DashboardPage {
   private readonly auth = inject(AuthSessionService);
   private readonly router = inject(Router);
+  readonly role = signal<DashboardRole>('employee');
+
+  readonly pageTitle = computed(() => {
+    switch (this.role()) {
+      case 'hr':
+      case 'admin':
+      case 'director':
+        return 'RH Dashboard';
+      case 'manager':
+        return 'Manager Dashboard';
+      case 'candidate':
+        return 'Candidate Dashboard';
+      case 'driver':
+      case 'employee':
+      default:
+        return 'Employee Dashboard';
+    }
+  });
+
+  readonly subtitle = computed(() => {
+    switch (this.role()) {
+      case 'hr':
+      case 'admin':
+      case 'director':
+        return 'Talent pipeline and logistics recruitment overview.';
+      case 'manager':
+        return 'Local terminal operations and assigned tests overview.';
+      case 'candidate':
+        return 'Follow your applications and pre-employment tests.';
+      case 'driver':
+      case 'employee':
+      default:
+        return 'Central operations hub and compliance monitoring.';
+    }
+  });
+
+  readonly statCards = computed(() => {
+    switch (this.role()) {
+      case 'hr':
+      case 'admin':
+      case 'director':
+        return [
+          { label: 'Open offers', value: '24', accent: 'blue' },
+          { label: 'Pending tests', value: '12', accent: 'cyan' },
+          { label: 'Priority calls', value: '08', accent: 'rose' },
+        ];
+      case 'manager':
+        return [
+          { label: "Today's assigned tests", value: '03', accent: 'blue' },
+          { label: 'Certification alerts', value: '02', accent: 'amber' },
+          { label: 'Candidates in process', value: '03', accent: 'emerald' },
+        ];
+      case 'candidate':
+        return [
+          { label: 'In progress', value: '04', accent: 'blue' },
+          { label: 'Tests to pass', value: '02', accent: 'cyan' },
+          { label: 'Interviews', value: '01', accent: 'violet' },
+        ];
+      case 'driver':
+      case 'employee':
+      default:
+        return [
+          { label: 'Global safety score', value: '92', accent: 'blue' },
+          { label: 'Active certifications', value: '04', accent: 'emerald' },
+          { label: 'Alerts', value: '01', accent: 'amber' },
+        ];
+    }
+  });
+
+  readonly quickAccess = computed<QuickAccessItem[]>(() => {
+    switch (this.role()) {
+      case 'hr':
+      case 'admin':
+      case 'director':
+        return [
+          { label: 'Offers', icon: '📁', route: '/positions', enabled: true },
+          { label: 'Candidates', icon: '👥', route: '/candidates', enabled: true },
+          { label: 'Tests', icon: '🧪', route: '/tests', enabled: true },
+          { label: 'Reports', icon: '📊', route: null, enabled: false }, // TODO: implement reports page
+        ];
+      case 'manager':
+        return [
+          { label: 'Assigned tests', icon: '🗂️', route: '/tests', enabled: true },
+          { label: 'Applicants', icon: '🧑‍💼', route: '/positions', enabled: true },
+          { label: 'Alerts', icon: '⚠️', route: null, enabled: false }, // TODO: manager alerts details page
+          { label: 'Local hub', icon: '🏭', route: null, enabled: false }, // TODO: terminal map/details page
+        ];
+      case 'candidate':
+        return [
+          { label: 'My tests', icon: '🧪', route: null, enabled: false }, // TODO: candidate tests route in internal frontend
+          { label: 'Applications', icon: '📨', route: null, enabled: false }, // TODO: candidate applications route in internal frontend
+          { label: 'Recommended jobs', icon: '💼', route: '/positions', enabled: true },
+          { label: 'Profile', icon: '🙍', route: null, enabled: false }, // TODO: candidate profile/settings route
+        ];
+      case 'driver':
+      case 'employee':
+      default:
+        return [
+          { label: 'Certifications', icon: '✅', route: null, enabled: false }, // TODO: certifications detailed route
+          { label: 'Security tests', icon: '🛡️', route: '/tests', enabled: true },
+          { label: 'Fleet docs', icon: '🚚', route: null, enabled: false }, // TODO: driver document center
+          { label: 'History', icon: '🕘', route: null, enabled: false }, // TODO: historical reports page
+        ];
+    }
+  });
+
+  constructor() {
+    this.auth
+      .loadMeOnce()
+      .pipe(take(1))
+      .subscribe((me) => {
+        const normalizedRole = (me?.role ?? 'employee') as DashboardRole;
+        this.role.set(normalizedRole);
+      });
+  }
+
+  openQuickAccess(item: QuickAccessItem): void {
+    if (!item.enabled || !item.route) {
+      return;
+    }
+    this.router.navigateByUrl(item.route);
+  }
 
   logout(): void {
     this.auth.logout();

--- a/apps/frontend/src/app/features/positions/pages/position-applicants.page.html
+++ b/apps/frontend/src/app/features/positions/pages/position-applicants.page.html
@@ -32,6 +32,12 @@
     </div>
   }
 
+  @if (!isLoading && !errorMessage && launchMessage) {
+    <div class="mb-3 rounded-xl border border-blue-500/25 bg-blue-500/10 p-3 text-sm text-blue-200">
+      {{ launchMessage }}
+    </div>
+  }
+
   @if (!isLoading && !errorMessage) {
     @if (filteredApplicants$ | async; as applicants) {
       <div class="space-y-3">
@@ -49,7 +55,36 @@
               </span>
             </div>
 
-            <p class="mt-3 text-xs text-slate-500">Applied at: {{ applicant.appliedAt }}</p>
+            <div class="mt-3 flex flex-wrap items-center gap-2 text-xs">
+              <span class="text-slate-500">Applied at: {{ applicant.appliedAt }}</span>
+              <span class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold text-emerald-300">
+                Ongoing tests: {{ applicant.ongoingTestsCount }}
+              </span>
+            </div>
+
+            @if (applicant.ongoingTestsCount > 0) {
+              <div class="mt-2 text-[11px] text-slate-400">
+                This applicant currently has active evaluations. See
+                <a class="text-blue-300 hover:text-blue-200" routerLink="/tests">Tests page</a>.
+              </div>
+            }
+
+            <div class="mt-3">
+              <button
+                type="button"
+                (click)="launchTest(applicant)"
+                [disabled]="
+                  isLaunching(applicant.applicationId) || applicant.ongoingTestsCount > 0
+                "
+                class="inline-flex items-center justify-center rounded-xl bg-blue-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                @if (applicant.ongoingTestsCount > 0) {
+                  Test already launched
+                } @else {
+                  {{ isLaunching(applicant.applicationId) ? 'Launching…' : 'Launch test' }}
+                }
+              </button>
+            </div>
           </article>
         }
 

--- a/apps/frontend/src/app/features/positions/pages/position-applicants.page.spec.ts
+++ b/apps/frontend/src/app/features/positions/pages/position-applicants.page.spec.ts
@@ -23,16 +23,32 @@ describe('PositionApplicantsPage', () => {
       phone: '+331111111',
       status: 'applied',
       appliedAt: '2026-04-08T10:00:00Z',
+      ongoingTestsCount: 2,
+      ongoingTestIds: [10, 11],
+    },
+    {
+      applicationId: 2,
+      candidateId: 8,
+      fullName: 'John Smith',
+      email: 'john@example.com',
+      phone: '+33222222',
+      status: 'applied',
+      appliedAt: '2026-04-08T09:00:00Z',
+      ongoingTestsCount: 0,
+      ongoingTestIds: [],
     },
   ];
 
   beforeEach(async () => {
     applicantsServiceSpy = jasmine.createSpyObj<PositionApplicantsService>(
       'PositionApplicantsService',
-      ['listByPosition'],
+      ['listByPosition', 'launchTestForApplication'],
     );
 
     applicantsServiceSpy.listByPosition.and.returnValue(of(applicants));
+    applicantsServiceSpy.launchTestForApplication.and.returnValue(
+      of([{ id: 91, application: 1, status: 'in_progress' }]),
+    );
 
     await TestBed.configureTestingModule({
       imports: [PositionApplicantsPage],
@@ -88,5 +104,19 @@ describe('PositionApplicantsPage', () => {
     expect(errorFixture.componentInstance.errorMessage).toBe(
       'Unable to load applicants for this position.',
     );
+  });
+
+  it('does not relaunch test for applicant with ongoing tests', () => {
+    component.launchTest(applicants[0]);
+
+    expect(applicantsServiceSpy.launchTestForApplication).not.toHaveBeenCalled();
+    expect(component.launchMessage).toContain('already has an ongoing test');
+  });
+
+  it('launches test for selected applicant without ongoing tests', () => {
+    component.launchTest(applicants[1]);
+
+    expect(applicantsServiceSpy.launchTestForApplication).toHaveBeenCalledWith(2);
+    expect(component.launchMessage).toContain('test(s) launched');
   });
 });

--- a/apps/frontend/src/app/features/positions/pages/position-applicants.page.ts
+++ b/apps/frontend/src/app/features/positions/pages/position-applicants.page.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   inject,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -26,12 +27,14 @@ export class PositionApplicantsPage {
   private readonly route = inject(ActivatedRoute);
   private readonly applicantsService = inject(PositionApplicantsService);
   private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly positionId = Number(this.route.snapshot.paramMap.get('id'));
   readonly searchControl = new FormControl('', { nonNullable: true });
 
   private readonly applicantsSubject = new BehaviorSubject<PositionApplicant[]>([]);
   readonly applicants$ = this.applicantsSubject.asObservable();
+  readonly launchingByApplication = new BehaviorSubject<Record<number, boolean>>({});
 
   readonly filteredApplicants$ = combineLatest([
     this.applicants$,
@@ -55,6 +58,7 @@ export class PositionApplicantsPage {
 
   isLoading = true;
   errorMessage: string | null = null;
+  launchMessage: string | null = null;
 
   constructor() {
     this.loadApplicants();
@@ -69,7 +73,7 @@ export class PositionApplicantsPage {
 
     this.applicantsService
       .listByPosition(this.positionId)
-      .pipe(takeUntilDestroyed())
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (applicants) => {
           this.applicantsSubject.next(applicants);
@@ -82,5 +86,43 @@ export class PositionApplicantsPage {
           this.cdr.markForCheck();
         },
       });
+  }
+
+  launchTest(applicant: PositionApplicant): void {
+    if (applicant.ongoingTestsCount > 0) {
+      this.launchMessage = `${applicant.fullName} already has an ongoing test.`;
+      this.cdr.markForCheck();
+      return;
+    }
+    this.launchMessage = null;
+    this.setLaunching(applicant.applicationId, true);
+    this.applicantsService
+      .launchTestForApplication(applicant.applicationId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (createdEvaluations) => {
+          this.launchMessage = `${createdEvaluations.length} test(s) launched for ${applicant.fullName}.`;
+          this.loadApplicants();
+          this.setLaunching(applicant.applicationId, false);
+        },
+        error: () => {
+          this.launchMessage = `Unable to launch test for ${applicant.fullName}.`;
+          this.setLaunching(applicant.applicationId, false);
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  isLaunching(applicationId: number): boolean {
+    return this.launchingByApplication.value[applicationId] ?? false;
+  }
+
+  private setLaunching(applicationId: number, value: boolean): void {
+    const next = {
+      ...this.launchingByApplication.value,
+      [applicationId]: value,
+    };
+    this.launchingByApplication.next(next);
+    this.cdr.markForCheck();
   }
 }

--- a/apps/frontend/src/app/features/positions/pages/position-editor.page.html
+++ b/apps/frontend/src/app/features/positions/pages/position-editor.page.html
@@ -21,6 +21,60 @@
         (submitForm)="submit()"
         (cancel)="cancel()"
       />
+
+      @if (state.status === 'ready-edit') {
+        <app-ui-card class="mt-4 block">
+          <h3 class="text-sm font-semibold text-slate-100">Test templates for this position</h3>
+          <p class="mt-1 text-xs text-slate-400">
+            Select templates included when launching a test from applicants. You can assign a manager ID per template.
+          </p>
+
+          <div class="mt-3 space-y-3">
+            @for (template of availableTemplates(); track template.id) {
+              <div class="rounded-xl border border-slate-700 p-3">
+                <label class="flex items-center gap-2 text-sm text-slate-200">
+                  <input
+                    type="checkbox"
+                    [checked]="selectedTemplateIds().includes(template.id)"
+                    (change)="toggleTemplate(template.id)"
+                  />
+                  <span>{{ template.name }} (#{{ template.id }})</span>
+                </label>
+
+                @if (selectedTemplateIds().includes(template.id)) {
+                  <div class="mt-2">
+                    <label class="text-xs text-slate-400" [attr.for]="'template-manager-' + template.id">Manager ID (optional)</label>
+                    <input
+                      [id]="'template-manager-' + template.id"
+                      type="number"
+                      class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100"
+                      [value]="managerByTemplate()[template.id] ?? ''"
+                      (input)="onTemplateManagerInput(template.id, $event)"
+                    />
+                  </div>
+                }
+              </div>
+            }
+          </div>
+
+          @if (templatesMessage()) {
+            <div class="mt-3 rounded-lg border border-blue-500/25 bg-blue-500/10 px-3 py-2 text-xs text-blue-200">
+              {{ templatesMessage() }}
+            </div>
+          }
+
+          <div class="mt-3">
+            <button
+              type="button"
+              class="rounded-xl bg-blue-600 px-3 py-2 text-xs font-semibold text-white hover:bg-blue-500 disabled:opacity-60"
+              (click)="saveTemplateAssignments()"
+              [disabled]="templatesSaving()"
+            >
+              {{ templatesSaving() ? 'Saving…' : 'Save test templates' }}
+            </button>
+          </div>
+        </app-ui-card>
+      }
     }
 
     <!-- LOADING (edit only) -->

--- a/apps/frontend/src/app/features/positions/pages/position-editor.page.ts
+++ b/apps/frontend/src/app/features/positions/pages/position-editor.page.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { toSignal, takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -7,7 +14,12 @@ import { catchError, map, of, startWith, switchMap, tap } from 'rxjs';
 import { PageShellComponent } from '@layout/page-shell/page-shell.component';
 import { PositionFormComponent } from '@features/positions/components/position-form/position-form.component';
 import { PositionFormService, PositionFormGroup } from '@features/positions/services/positions-form.service';
-import { PositionsApiService, PositionCreatePayload, PositionDto } from '@features/positions/services/positions-api.service';
+import {
+  PositionCreatePayload,
+  PositionDto,
+  PositionsApiService,
+  TemplateOptionDto,
+} from '@features/positions/services/positions-api.service';
 
 import { UiLinkButtonComponent } from '@lib-ui/link-button/ui-link-button.component';
 import { UiCardComponent } from '@lib-ui/card/card.component';
@@ -44,12 +56,18 @@ export class PositionEditorPage {
   private readonly api = inject(PositionsApiService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly form: PositionFormGroup = this.formService.build();
 
   readonly isSubmitting = signal(false);
   readonly apiError = signal<string | null>(null);
   readonly fieldErrors = signal<Record<string, string[]>>({});
+  readonly availableTemplates = signal<TemplateOptionDto[]>([]);
+  readonly selectedTemplateIds = signal<number[]>([]);
+  readonly managerByTemplate = signal<Partial<Record<number, string>>>({});
+  readonly templatesMessage = signal<string | null>(null);
+  readonly templatesSaving = signal(false);
 
   // ✅ Observable id
   private readonly positionId$ = this.route.paramMap.pipe(
@@ -106,6 +124,10 @@ export class PositionEditorPage {
   // ✅ Signal state
   readonly state = toSignal(this.state$, { initialValue: { status: 'loading' } as const });
 
+  constructor() {
+    this.loadTemplateConfiguration();
+  }
+
   submit(): void {
     this.apiError.set(null);
     this.fieldErrors.set({});
@@ -122,7 +144,7 @@ export class PositionEditorPage {
 
     const req$ = id !== null ? this.api.patch(id, payload) : this.api.create(payload);
 
-    req$.pipe(takeUntilDestroyed()).subscribe({
+    req$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: () => {
         this.isSubmitting.set(false);
         void this.router.navigateByUrl('/positions');
@@ -139,6 +161,70 @@ export class PositionEditorPage {
 
   cancel(): void {
     void this.router.navigateByUrl('/positions');
+  }
+
+  toggleTemplate(templateId: number): void {
+    const current = this.selectedTemplateIds();
+    if (current.includes(templateId)) {
+      this.selectedTemplateIds.set(current.filter((id) => id !== templateId));
+      return;
+    }
+    this.selectedTemplateIds.set([...current, templateId]);
+  }
+
+  updateTemplateManager(templateId: number, rawValue: string): void {
+    this.managerByTemplate.set({
+      ...this.managerByTemplate(),
+      [templateId]: rawValue.trim(),
+    });
+  }
+
+  onTemplateManagerInput(templateId: number, event: Event): void {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) {
+      return;
+    }
+    this.updateTemplateManager(templateId, target.value);
+  }
+
+  saveTemplateAssignments(): void {
+    const id = this.positionId();
+    if (id === null) {
+      this.templatesMessage.set('Save the position first before assigning templates.');
+      return;
+    }
+
+    this.templatesSaving.set(true);
+    this.templatesMessage.set(null);
+    const managerByTemplate = this.managerByTemplate();
+    const payload = this.selectedTemplateIds().map((templateId, index) => {
+      const managerRaw = managerByTemplate[templateId] ?? '';
+      const managerId = Number(managerRaw);
+      return {
+        template_id: templateId,
+        manager_id:
+          managerRaw.length > 0 && Number.isInteger(managerId) && managerId > 0
+            ? managerId
+            : null,
+        order: index,
+      };
+    });
+
+    this.api
+      .setPositionTemplateAssignments(id, payload)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.templatesSaving.set(false);
+          this.templatesMessage.set('Position test templates saved.');
+        },
+        error: () => {
+          this.templatesSaving.set(false);
+          this.templatesMessage.set(
+            'Unable to save template assignments. Check manager IDs and try again.',
+          );
+        },
+      });
   }
 
   private handleApiError(err: unknown, fallback: string): void {
@@ -165,5 +251,34 @@ export class PositionEditorPage {
     }
 
     this.apiError.set(fallback);
+  }
+
+  private loadTemplateConfiguration(): void {
+    this.api
+      .listTemplates()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (templates) => {
+          this.availableTemplates.set(templates);
+
+          const id = this.positionId();
+          if (id === null) return;
+
+          this.api
+            .getPositionTemplateAssignments(id)
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+              next: (assignments) => {
+                this.selectedTemplateIds.set(assignments.map((item) => item.template));
+                this.managerByTemplate.set(
+                  assignments.reduce<Record<number, string>>((acc, item) => {
+                    acc[item.template] = item.manager_id ? String(item.manager_id) : '';
+                    return acc;
+                  }, {}),
+                );
+              },
+            });
+        },
+      });
   }
 }

--- a/apps/frontend/src/app/features/positions/pages/positions-list.page.html
+++ b/apps/frontend/src/app/features/positions/pages/positions-list.page.html
@@ -50,6 +50,7 @@
   @if (!isLoading && !error) {
 
     @if (filteredPositions$ | async; as positions) {
+      @if (appliedCountByPosition$ | async; as appliedCounts) {
 
       <div class="space-y-3">
 
@@ -86,7 +87,9 @@
 
             <div class="mt-4 flex items-end justify-between">
               <div class="text-[11px] text-slate-400">
-                <a class="text-blue-300 hover:text-blue-200" [routerLink]="['/positions', p.id, 'applicants']">Applicants: view list</a>
+                <a class="text-blue-300 hover:text-blue-200" [routerLink]="['/positions', p.id, 'applicants']">
+                  Applicants: {{ getAppliedCount(p.id, appliedCounts) }}
+                </a>
                 <div class="text-slate-500">Closing: —</div>
               </div>
 
@@ -109,6 +112,7 @@
         }
 
       </div>
+      }
     }
   }
 

--- a/apps/frontend/src/app/features/positions/pages/positions-list.page.spec.ts
+++ b/apps/frontend/src/app/features/positions/pages/positions-list.page.spec.ts
@@ -6,11 +6,13 @@ import { PositionsApiService, PositionDto } from '@features/positions/services/p
 
 interface PositionsApiServiceMock {
   list: jasmine.Spy<() => ReturnType<PositionsApiService['list']>>;
+  listApplicationCounts: jasmine.Spy<() => ReturnType<PositionsApiService['listApplicationCounts']>>;
 }
 
 function makeApiMock(initial: unknown = []): PositionsApiServiceMock {
   return {
     list: jasmine.createSpy('list').and.returnValue(of(initial)),
+    listApplicationCounts: jasmine.createSpy('listApplicationCounts').and.returnValue(of({})),
   };
 }
 
@@ -57,6 +59,7 @@ describe('PositionsListPage', () => {
   it('should call api.list() on init', () => {
     const { apiMock } = setup();
     expect(apiMock.list).toHaveBeenCalledTimes(1);
+    expect(apiMock.listApplicationCounts).toHaveBeenCalledTimes(1);
   });
 
   it('should accept paginated API payloads { results: PositionDto[] }', async () => {
@@ -96,5 +99,11 @@ describe('PositionsListPage', () => {
     const p = makePosition({ title: 'Driver', is_active: true });
 
     expect(component.getBadge(p)).toEqual({ label: 'ACTIVE', tone: 'success' });
+  });
+
+  it('getAppliedCount() should return application count for a position', () => {
+    const { component } = setup();
+    expect(component.getAppliedCount(12, { 12: 5 })).toBe(5);
+    expect(component.getAppliedCount(99, { 12: 5 })).toBe(0);
   });
 });

--- a/apps/frontend/src/app/features/positions/pages/positions-list.page.ts
+++ b/apps/frontend/src/app/features/positions/pages/positions-list.page.ts
@@ -1,7 +1,13 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { BehaviorSubject, combineLatest, map, startWith } from 'rxjs';
+import { BehaviorSubject, combineLatest, forkJoin, map, startWith } from 'rxjs';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -9,6 +15,7 @@ import { PositionsApiService, PositionDto } from '@features/positions/services/p
 
 import { UiBadgeComponent, UiBadgeTone } from '@lib-ui/badge/badge.component';
 import { UiSelectComponent, UiSelectOption } from '@lib-ui/select/select.component';
+import { UiTextInputComponent } from '@lib-ui/text-input/text-input.component';
 
 type LocationValue = 'all' | 'chicago' | 'dallas' | 'phoenix' | 'remote';
 type TruckTypeValue = 'all' | 'long-haul' | 'dry-van' | 'tanker' | 'flatbed';
@@ -47,6 +54,7 @@ function asArrayOrResults<T>(value: unknown): T[] {
     ReactiveFormsModule,
     UiSelectComponent,
     UiBadgeComponent,
+    UiTextInputComponent,
   ],
   templateUrl: './positions-list.page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -54,9 +62,12 @@ function asArrayOrResults<T>(value: unknown): T[] {
 export class PositionsListPage {
   private readonly api = inject(PositionsApiService);
   private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
 
   private readonly positionsSubject = new BehaviorSubject<PositionDto[]>([]);
   readonly positions$ = this.positionsSubject.asObservable();
+  private readonly appliedCountByPositionSubject = new BehaviorSubject<Record<number, number>>({});
+  readonly appliedCountByPosition$ = this.appliedCountByPositionSubject.asObservable();
 
   // Search + dropdown filters
   readonly searchCtrl = new FormControl('', { nonNullable: true });
@@ -141,13 +152,16 @@ export class PositionsListPage {
     this.error = null;
     this.cdr.markForCheck();
 
-    this.api
-      .list()
-      .pipe(takeUntilDestroyed())
+    forkJoin({
+      positions: this.api.list(),
+      applicationCounts: this.api.listApplicationCounts(),
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (data: unknown) => {
-          const list = asArrayOrResults<PositionDto>(data);
+        next: ({ positions, applicationCounts }) => {
+          const list = asArrayOrResults<PositionDto>(positions);
           this.positionsSubject.next(list);
+          this.appliedCountByPositionSubject.next(applicationCounts);
 
           this.isLoading = false;
           this.cdr.markForCheck();
@@ -168,5 +182,9 @@ export class PositionsListPage {
     if (t.includes('tanker')) return { label: 'MEDIUM', tone: 'warning' };
 
     return { label: 'ACTIVE', tone: 'success' };
+  }
+
+  getAppliedCount(positionId: number, counts: Record<number, number>): number {
+    return counts[positionId] ?? 0;
   }
 }

--- a/apps/frontend/src/app/features/positions/services/position-applicants.service.spec.ts
+++ b/apps/frontend/src/app/features/positions/services/position-applicants.service.spec.ts
@@ -24,15 +24,18 @@ describe('PositionApplicantsService', () => {
     httpMock.verify();
   });
 
-  it('maps applicants for a position with candidate details', () => {
+  it('maps applicants for a position with candidate details and ongoing tests count', () => {
     let names: string[] = [];
+    let ongoingTestsCount = 0;
 
     service.listByPosition(9).subscribe((applicants) => {
       names = applicants.map((applicant) => applicant.fullName);
+      ongoingTestsCount = applicants[0]?.ongoingTestsCount ?? 0;
     });
 
     const applicationsRequest = httpMock.expectOne('/api/jobapplications/');
     const candidatesRequest = httpMock.expectOne('/api/candidates/');
+    const evaluationsRequest = httpMock.expectOne('/api/evaluations/');
 
     applicationsRequest.flush([
       {
@@ -62,7 +65,281 @@ describe('PositionApplicantsService', () => {
         },
       },
     ]);
+    evaluationsRequest.flush([
+      {
+        id: 700,
+        application: 1,
+        status: 'in_progress',
+        updated_at: '2026-04-08T11:00:00Z',
+      },
+    ]);
 
     expect(names).toEqual(['Jane Doe']);
+    expect(ongoingTestsCount).toBe(1);
+  });
+
+  it('lists in-progress tests for all positions', () => {
+    let ids: number[] = [];
+
+    service.listInProgressTests().subscribe((testsInProgress) => {
+      ids = testsInProgress.map((item) => item.evaluationId);
+      expect(testsInProgress[0].positionTitle).toBe('Driver Linehaul');
+      expect(testsInProgress[0].candidateName).toBe('Jane Doe');
+    });
+
+    const applicationsRequest = httpMock.expectOne('/api/jobapplications/');
+    const candidatesRequest = httpMock.expectOne('/api/candidates/');
+    const evaluationsRequest = httpMock.expectOne('/api/evaluations/');
+    const positionsRequest = httpMock.expectOne('/api/positions/');
+
+    applicationsRequest.flush([
+      {
+        id: 1,
+        candidate: 11,
+        position: 9,
+        status: 'applied',
+        created_at: '2026-04-08T10:00:00Z',
+      },
+    ]);
+    candidatesRequest.flush([
+      {
+        id: 11,
+        user: {
+          first_name: 'Jane',
+          last_name: 'Doe',
+          email: 'jane@example.com',
+          phone: '+330000000',
+        },
+      },
+    ]);
+    evaluationsRequest.flush([
+      {
+        id: 700,
+        application: 1,
+        status: 'in_progress',
+        updated_at: '2026-04-08T11:00:00Z',
+      },
+      {
+        id: 701,
+        application: 1,
+        status: 'completed',
+        updated_at: '2026-04-08T12:00:00Z',
+      },
+    ]);
+    positionsRequest.flush([
+      {
+        id: 9,
+        title: 'Driver Linehaul',
+      },
+    ]);
+
+    expect(ids).toEqual([700]);
+  });
+
+  it('follows paginated responses so newly launched tests are visible', () => {
+    let ids: number[] = [];
+
+    service.listInProgressTests().subscribe((testsInProgress) => {
+      ids = testsInProgress.map((item) => item.evaluationId);
+    });
+
+    httpMock.expectOne('/api/jobapplications/').flush({
+      results: [],
+      next: '/api/jobapplications/?page=2',
+    });
+    httpMock.expectOne('/api/jobapplications/?page=2').flush({
+      results: [
+        {
+          id: 9,
+          candidate: 51,
+          position: 88,
+          status: 'applied',
+          created_at: '2026-04-08T10:00:00Z',
+        },
+      ],
+      next: null,
+    });
+
+    httpMock.expectOne('/api/candidates/').flush({
+      results: [],
+      next: '/api/candidates/?page=2',
+    });
+    httpMock.expectOne('/api/candidates/?page=2').flush({
+      results: [
+        {
+          id: 51,
+          user: {
+            first_name: 'New',
+            last_name: 'Candidate',
+            email: 'new@example.com',
+          },
+        },
+      ],
+      next: null,
+    });
+
+    httpMock.expectOne('/api/evaluations/').flush({
+      results: [],
+      next: '/api/evaluations/?page=2',
+    });
+    httpMock.expectOne('/api/evaluations/?page=2').flush({
+      results: [
+        {
+          id: 999,
+          application: 9,
+          status: 'in_progress',
+          updated_at: '2026-04-09T11:00:00Z',
+        },
+      ],
+      next: null,
+    });
+
+    httpMock.expectOne('/api/positions/').flush({
+      results: [],
+      next: '/api/positions/?page=2',
+    });
+    httpMock.expectOne('/api/positions/?page=2').flush({
+      results: [{ id: 88, title: 'Night Driver' }],
+      next: null,
+    });
+
+    expect(ids).toEqual([999]);
+  });
+
+  it('lists launchable templates', () => {
+    let templateNames: string[] = [];
+
+    service.listLaunchableTemplates().subscribe((templates) => {
+      templateNames = templates.map((template) => template.name);
+    });
+
+    const request = httpMock.expectOne('/api/templates/');
+    request.flush([
+      { id: 1, name: 'Driver template' },
+      { id: 2, name: 'Manager template' },
+    ]);
+
+    expect(templateNames).toEqual(['Driver template', 'Manager template']);
+  });
+
+  it('launches a test for an application', () => {
+    let responseId = 0;
+
+    service.launchTestForApplication(10, 3).subscribe((response) => {
+      responseId = response[0].id;
+    });
+
+    const request = httpMock.expectOne('/api/evaluations/launch/');
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual({
+      application_id: 10,
+      template_id: 3,
+    });
+
+    request.flush([
+      {
+        id: 55,
+        application: 10,
+        status: 'in_progress',
+      },
+    ]);
+
+    expect(responseId).toBe(55);
+  });
+
+  it('launches a test using position default templates when no explicit template id is provided', () => {
+    service.launchTestForApplication(99).subscribe((response) => {
+      expect(response.length).toBe(1);
+      expect(response[0].id).toBe(56);
+    });
+
+    const request = httpMock.expectOne('/api/evaluations/launch/');
+    expect(request.request.body).toEqual({
+      application_id: 99,
+    });
+
+    request.flush([
+      {
+        id: 56,
+        application: 99,
+        status: 'in_progress',
+      },
+    ]);
+  });
+
+  it('assigns a manager to an evaluation', () => {
+    let assignedTo: number | null = null;
+    service.assignManagerToEvaluation(70, 12).subscribe((response) => {
+      assignedTo = response.assigned_to;
+    });
+
+    const request = httpMock.expectOne('/api/evaluations/70/');
+    expect(request.request.method).toBe('PATCH');
+    expect(request.request.body).toEqual({ assigned_to: 12 });
+    request.flush({ id: 70, assigned_to: 12 });
+
+    if (assignedTo === null) {
+      fail('assignedTo should not be null');
+      return;
+    }
+    expect(assignedTo).toBe(12);
+  });
+
+  it('lists managers with optional search query', () => {
+    let managerIds: number[] = [];
+    service.listManagers('alice').subscribe((managers) => {
+      managerIds = managers.map((manager) => manager.id);
+    });
+
+    const request = httpMock.expectOne('/api/evaluations/managers/?q=alice');
+    expect(request.request.method).toBe('GET');
+    request.flush([
+      {
+        id: 9,
+        full_name: 'Alice Manager',
+        email: 'alice.manager@example.com',
+      },
+    ]);
+
+    expect(managerIds).toEqual([9]);
+  });
+
+  it('loads questionnaire for an evaluation', () => {
+    let questionCount = 0;
+    service.getEvaluationQuestionnaire(44).subscribe((payload) => {
+      questionCount = payload.questions.length;
+    });
+
+    const request = httpMock.expectOne('/api/evaluations/44/questionnaire/');
+    expect(request.request.method).toBe('GET');
+    request.flush({
+      evaluation_id: 44,
+      template_name: 'Template',
+      questions: [{ question_id: 1, title: 'Q', text: 'T', is_mandatory: true, points: 5, candidate_answer: '', manager_comment: '', score: null }],
+    });
+
+    expect(questionCount).toBe(1);
+  });
+
+  it('saves questionnaire answers', () => {
+    let saved = false;
+    service
+      .saveEvaluationQuestionnaire(44, [
+        { question_id: 1, candidate_answer: 'A', manager_comment: 'C', score: 4 },
+      ])
+      .subscribe(() => {
+        saved = true;
+      });
+
+    const request = httpMock.expectOne('/api/evaluations/44/questionnaire/');
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body.answers.length).toBe(1);
+    request.flush({
+      evaluation_id: 44,
+      template_name: 'Template',
+      questions: [{ question_id: 1, title: 'Q', text: 'T', is_mandatory: true, points: 5, candidate_answer: 'A', manager_comment: 'C', score: 4 }],
+    });
+
+    expect(saved).toBeTrue();
   });
 });

--- a/apps/frontend/src/app/features/positions/services/position-applicants.service.ts
+++ b/apps/frontend/src/app/features/positions/services/position-applicants.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, forkJoin, map } from 'rxjs';
+import { EMPTY, Observable, expand, forkJoin, map, reduce } from 'rxjs';
 
 interface Paginated<T> {
   results: T[];
+  next?: string | null;
 }
 
 interface JobApplicationDto {
@@ -24,6 +25,24 @@ interface CandidateDto {
   };
 }
 
+interface PositionDto {
+  id: number;
+  title: string;
+}
+
+interface TemplateDto {
+  id: number;
+  name: string;
+}
+
+interface EvaluationDto {
+  id: number;
+  application: number | null;
+  status: string;
+  updated_at: string;
+  template_name?: string;
+}
+
 export interface PositionApplicant {
   applicationId: number;
   candidateId: number;
@@ -32,10 +51,67 @@ export interface PositionApplicant {
   phone: string;
   status: string;
   appliedAt: string;
+  ongoingTestsCount: number;
+  ongoingTestIds: number[];
 }
 
-function asList<T>(value: T[] | Paginated<T>): T[] {
-  return Array.isArray(value) ? value : value.results;
+export interface InProgressTestItem {
+  evaluationId: number;
+  applicationId: number;
+  candidateId: number;
+  candidateName: string;
+  candidateEmail: string;
+  positionId: number;
+  positionTitle: string;
+  templateName: string;
+  updatedAt: string;
+}
+
+export interface QuestionnaireQuestion {
+  question_id: number;
+  title: string;
+  text: string;
+  is_mandatory: boolean;
+  points: number;
+  candidate_answer: string;
+  manager_comment: string;
+  score: number | null;
+}
+
+export interface EvaluationQuestionnaire {
+  evaluation_id: number;
+  template_name: string;
+  questions: QuestionnaireQuestion[];
+}
+
+export interface LaunchableTemplate {
+  id: number;
+  name: string;
+}
+
+export interface ManagerOption {
+  id: number;
+  full_name: string;
+  email: string;
+}
+
+interface LaunchEvaluationPayload {
+  application_id: number;
+  template_id?: number;
+  assigned_to_id?: number;
+}
+
+interface LaunchEvaluationResponse {
+  id: number;
+  application: number;
+  status: string;
+}
+
+function isPaginatedPayload<T>(value: unknown): value is Paginated<T> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return Array.isArray((value as Paginated<T>).results);
 }
 
 @Injectable({ providedIn: 'root' })
@@ -44,24 +120,39 @@ export class PositionApplicantsService {
 
   private readonly applicationsUrl = '/api/jobapplications/';
   private readonly candidatesUrl = '/api/candidates/';
+  private readonly evaluationsUrl = '/api/evaluations/';
+  private readonly positionsUrl = '/api/positions/';
+  private readonly templatesUrl = '/api/templates/';
+
+  private fetchAllPages<T>(url: string): Observable<T[]> {
+    return this.http.get<T[] | Paginated<T>>(url).pipe(
+      expand((payload) => {
+        if (!isPaginatedPayload<T>(payload) || !payload.next) {
+          return EMPTY;
+        }
+        return this.http.get<T[] | Paginated<T>>(payload.next);
+      }),
+      map((payload) => (isPaginatedPayload<T>(payload) ? payload.results : payload)),
+      reduce((allRows, pageRows) => [...allRows, ...pageRows], [] as T[]),
+    );
+  }
 
   listByPosition(positionId: number): Observable<PositionApplicant[]> {
     return forkJoin({
-      applications: this.http
-        .get<JobApplicationDto[] | Paginated<JobApplicationDto>>(this.applicationsUrl)
-        .pipe(map(asList)),
-      candidates: this.http
-        .get<CandidateDto[] | Paginated<CandidateDto>>(this.candidatesUrl)
-        .pipe(map(asList)),
+      applications: this.fetchAllPages<JobApplicationDto>(this.applicationsUrl),
+      candidates: this.fetchAllPages<CandidateDto>(this.candidatesUrl),
+      evaluations: this.fetchAllPages<EvaluationDto>(this.evaluationsUrl),
     }).pipe(
-      map(({ applications, candidates }) => {
+      map(({ applications, candidates, evaluations }) => {
         const candidateById = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+        const ongoingTestsByApplication = this.getOngoingTestsByApplication(evaluations);
 
         return applications
           .filter((application) => application.position === positionId)
           .sort((left, right) => right.created_at.localeCompare(left.created_at))
           .map((application) => {
             const candidate = candidateById.get(application.candidate);
+            const ongoingTests = ongoingTestsByApplication.get(application.id) ?? [];
 
             return {
               applicationId: application.id,
@@ -73,9 +164,140 @@ export class PositionApplicantsService {
               phone: candidate?.user.phone ?? '',
               status: application.status,
               appliedAt: application.created_at,
+              ongoingTestsCount: ongoingTests.length,
+              ongoingTestIds: ongoingTests.map((item) => item.id),
             };
           });
       }),
     );
+  }
+
+  listInProgressTests(): Observable<InProgressTestItem[]> {
+    return forkJoin({
+      applications: this.fetchAllPages<JobApplicationDto>(this.applicationsUrl),
+      candidates: this.fetchAllPages<CandidateDto>(this.candidatesUrl),
+      evaluations: this.fetchAllPages<EvaluationDto>(this.evaluationsUrl),
+      positions: this.fetchAllPages<PositionDto>(this.positionsUrl),
+    }).pipe(
+      map(({ applications, candidates, evaluations, positions }) => {
+        const applicationById = new Map(applications.map((application) => [application.id, application]));
+        const candidateById = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+        const positionById = new Map(positions.map((position) => [position.id, position]));
+
+        return evaluations
+          .filter((evaluation) => evaluation.status === 'in_progress' && evaluation.application !== null)
+          .map((evaluation) => {
+            const application = evaluation.application ? applicationById.get(evaluation.application) : undefined;
+            if (!application) {
+              return null;
+            }
+
+            const candidate = candidateById.get(application.candidate);
+            const position = positionById.get(application.position);
+            const candidateName = candidate
+              ? `${candidate.user.first_name} ${candidate.user.last_name}`.trim()
+              : `Candidate #${application.candidate}`;
+
+            return {
+              evaluationId: evaluation.id,
+              applicationId: application.id,
+              candidateId: application.candidate,
+              candidateName,
+              candidateEmail: candidate?.user.email ?? 'Unknown email',
+              positionId: application.position,
+              positionTitle: position?.title ?? `Position #${application.position}`,
+              templateName: evaluation.template_name ?? 'Template',
+              updatedAt: evaluation.updated_at,
+            };
+          })
+          .filter((item): item is InProgressTestItem => item !== null)
+          .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+      }),
+    );
+  }
+
+  listLaunchableTemplates(): Observable<LaunchableTemplate[]> {
+    return this.fetchAllPages<TemplateDto>(this.templatesUrl).pipe(
+      map((templates) =>
+        templates.map((template) => ({ id: template.id, name: template.name })),
+      ),
+    );
+  }
+
+  launchTestForApplication(
+    applicationId: number,
+    templateId?: number,
+  ): Observable<LaunchEvaluationResponse[]> {
+    const payload: LaunchEvaluationPayload = {
+      application_id: applicationId,
+    };
+    if (templateId !== undefined) {
+      payload.template_id = templateId;
+    }
+
+    return this.http
+      .post<LaunchEvaluationResponse | LaunchEvaluationResponse[]>(
+        '/api/evaluations/launch/',
+        payload,
+      )
+      .pipe(map((response) => (Array.isArray(response) ? response : [response])));
+  }
+
+  assignManagerToEvaluation(
+    evaluationId: number,
+    managerId: number,
+  ): Observable<{ id: number; assigned_to: number | null }> {
+    return this.http.patch<{ id: number; assigned_to: number | null }>(
+      `/api/evaluations/${evaluationId}/`,
+      { assigned_to: managerId },
+    );
+  }
+
+  listManagers(query = ''): Observable<ManagerOption[]> {
+    const normalized = query.trim();
+    const url = normalized
+      ? `/api/evaluations/managers/?q=${encodeURIComponent(normalized)}`
+      : '/api/evaluations/managers/';
+    return this.http.get<ManagerOption[]>(url);
+  }
+
+  getEvaluationQuestionnaire(evaluationId: number): Observable<EvaluationQuestionnaire> {
+    return this.http.get<EvaluationQuestionnaire>(
+      `/api/evaluations/${evaluationId}/questionnaire/`,
+    );
+  }
+
+  saveEvaluationQuestionnaire(
+    evaluationId: number,
+    answers: {
+      question_id: number;
+      candidate_answer: string;
+      manager_comment: string;
+      score: number | null;
+    }[],
+  ): Observable<EvaluationQuestionnaire> {
+    return this.http.post<EvaluationQuestionnaire>(
+      `/api/evaluations/${evaluationId}/questionnaire/`,
+      { answers },
+    );
+  }
+
+  private getOngoingTestsByApplication(
+    evaluations: EvaluationDto[],
+  ): Map<number, EvaluationDto[]> {
+    const byApplication = new Map<number, EvaluationDto[]>();
+
+    for (const evaluation of evaluations) {
+      if (evaluation.status !== 'in_progress' || evaluation.application === null) {
+        continue;
+      }
+
+      const appId = evaluation.application;
+      const existing = byApplication.get(appId) ?? [];
+      existing.push(evaluation);
+      byApplication.set(appId, existing);
+    }
+
+    return byApplication;
   }
 }

--- a/apps/frontend/src/app/features/positions/services/positions-api.service.spec.ts
+++ b/apps/frontend/src/app/features/positions/services/positions-api.service.spec.ts
@@ -10,11 +10,13 @@ import {
 
 interface PositionsApiServiceMock {
   list: jasmine.Spy<() => ReturnType<PositionsApiService['list']>>;
+  listApplicationCounts: jasmine.Spy<() => ReturnType<PositionsApiService['listApplicationCounts']>>;
 }
 
 function makeApiMock(initial: PositionDto[] | Paginated<PositionDto> = []): PositionsApiServiceMock {
   return {
     list: jasmine.createSpy('list').and.returnValue(of(initial)),
+    listApplicationCounts: jasmine.createSpy('listApplicationCounts').and.returnValue(of({})),
   };
 }
 
@@ -59,6 +61,7 @@ describe('PositionsListPage', () => {
   it('should call api.list() on init', () => {
     const { apiMock } = setup();
     expect(apiMock.list).toHaveBeenCalledTimes(1);
+    expect(apiMock.listApplicationCounts).toHaveBeenCalledTimes(1);
   });
 
   it('should accept list API payloads (PositionDto[])', async () => {

--- a/apps/frontend/src/app/features/positions/services/positions-api.service.ts
+++ b/apps/frontend/src/app/features/positions/services/positions-api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
 export interface PositionCreatePayload {
   company: number;
@@ -24,11 +24,42 @@ export interface Paginated<T> {
   results: T[];
 }
 
+interface JobApplicationLiteDto {
+  position: number;
+}
+
+export interface TemplateOptionDto {
+  id: number;
+  name: string;
+}
+
+export interface PositionTemplateAssignmentDto {
+  id: number;
+  position: number;
+  template: number;
+  template_name: string;
+  manager_id: number | null;
+  manager_name: string | null;
+  order: number;
+}
+
+export interface PositionTemplateAssignmentInput {
+  template_id: number;
+  manager_id?: number | null;
+  order?: number;
+}
+
+function asArray<T>(value: T[] | Paginated<T>): T[] {
+  return Array.isArray(value) ? value : value.results;
+}
+
 @Injectable({ providedIn: 'root' })
 export class PositionsApiService {
   private readonly http = inject(HttpClient);
 
   private readonly baseUrl = '/api/positions/';
+  private readonly jobApplicationsUrl = '/api/jobapplications/';
+  private readonly templatesUrl = '/api/templates/';
 
   create(payload: PositionCreatePayload): Observable<PositionDto> {
     return this.http.post<PositionDto>(this.baseUrl, payload);
@@ -45,5 +76,41 @@ export class PositionsApiService {
 
   patch(id: number, payload: Partial<PositionCreatePayload>): Observable<PositionDto> {
     return this.http.patch<PositionDto>(`${this.baseUrl}${id}/`, payload);
+  }
+
+  listApplicationCounts(): Observable<Record<number, number>> {
+    return this.http
+      .get<JobApplicationLiteDto[] | Paginated<JobApplicationLiteDto>>(this.jobApplicationsUrl)
+      .pipe(
+        map((payload) => {
+          const counts: Record<number, number> = {};
+          for (const application of asArray(payload)) {
+            counts[application.position] = (counts[application.position] ?? 0) + 1;
+          }
+          return counts;
+        }),
+      );
+  }
+
+  listTemplates(): Observable<TemplateOptionDto[]> {
+    return this.http
+      .get<TemplateOptionDto[] | Paginated<TemplateOptionDto>>(this.templatesUrl)
+      .pipe(map(asArray));
+  }
+
+  getPositionTemplateAssignments(positionId: number): Observable<PositionTemplateAssignmentDto[]> {
+    return this.http.get<PositionTemplateAssignmentDto[]>(
+      `${this.baseUrl}${positionId}/test-templates/`,
+    );
+  }
+
+  setPositionTemplateAssignments(
+    positionId: number,
+    assignments: PositionTemplateAssignmentInput[],
+  ): Observable<PositionTemplateAssignmentDto[]> {
+    return this.http.put<PositionTemplateAssignmentDto[]>(
+      `${this.baseUrl}${positionId}/test-templates/`,
+      { assignments },
+    );
   }
 }

--- a/apps/frontend/src/app/features/roles/pages/roles-admin.page.html
+++ b/apps/frontend/src/app/features/roles/pages/roles-admin.page.html
@@ -1,0 +1,108 @@
+<section class="min-h-[calc(100vh-144px)] bg-slate-950 p-4 text-slate-100">
+  <header class="mb-4 flex items-center justify-between gap-3">
+    <div>
+      <h1 class="text-xl font-semibold">Role Management</h1>
+      <p class="text-sm text-slate-400">Admin-only user and role administration</p>
+    </div>
+    <a
+      [routerLink]="['/dashboard']"
+      class="rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-200 hover:bg-slate-800"
+    >
+      Back to dashboard
+    </a>
+  </header>
+
+  @if (pageMessage) {
+    <div class="mb-3 rounded-xl border border-blue-500/25 bg-blue-500/10 p-3 text-sm text-blue-200">
+      {{ pageMessage }}
+    </div>
+  }
+
+  <article class="mb-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+    <h2 class="mb-3 text-sm font-semibold">Create user</h2>
+    <form [formGroup]="createForm" (ngSubmit)="createUser()" class="grid gap-2 md:grid-cols-2">
+      <input
+        formControlName="email"
+        type="email"
+        placeholder="Email"
+        class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm"
+      />
+      <input
+        formControlName="password"
+        type="password"
+        placeholder="Temporary password"
+        class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm"
+      />
+      <input
+        formControlName="first_name"
+        type="text"
+        placeholder="First name"
+        class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm"
+      />
+      <input
+        formControlName="last_name"
+        type="text"
+        placeholder="Last name"
+        class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm"
+      />
+      <select
+        formControlName="role"
+        class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm"
+      >
+        @for (role of roleOptions; track role) {
+          <option [value]="role">{{ role }}</option>
+        }
+      </select>
+      <button
+        type="submit"
+        class="rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+      >
+        Create user
+      </button>
+    </form>
+  </article>
+
+  <article class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+    <h2 class="mb-3 text-sm font-semibold">Existing users</h2>
+    <p class="mb-2 text-xs text-slate-400">
+      Role changes are saved automatically when you change the dropdown.
+    </p>
+    @if (isLoading) {
+      <p class="text-sm text-slate-400">Loading users…</p>
+    } @else {
+      <div class="space-y-2">
+        @for (user of users; track user.id) {
+          <div class="rounded-xl border border-slate-700 p-3">
+            <div class="mb-2 flex items-center justify-between gap-2">
+              <div>
+                <p class="text-sm font-semibold">{{ user.first_name }} {{ user.last_name }}</p>
+                <p class="text-xs text-slate-400">{{ user.email }}</p>
+              </div>
+              <span class="text-xs" [class.text-emerald-300]="user.is_active" [class.text-red-300]="!user.is_active">
+                {{ user.is_active ? 'Active' : 'Inactive' }}
+              </span>
+            </div>
+            <div class="flex flex-wrap items-center gap-2">
+              <select
+                class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-xs"
+                [value]="user.role"
+                (change)="onRoleChange(user, $event)"
+              >
+                @for (role of roleOptions; track role) {
+                  <option [value]="role">{{ role }}</option>
+                }
+              </select>
+              <button
+                type="button"
+                class="rounded-lg border border-slate-700 px-3 py-2 text-xs hover:bg-slate-800"
+                (click)="toggleUser(user)"
+              >
+                {{ user.is_active ? 'Deactivate' : 'Activate' }}
+              </button>
+            </div>
+          </div>
+        }
+      </div>
+    }
+  </article>
+</section>

--- a/apps/frontend/src/app/features/roles/pages/roles-admin.page.spec.ts
+++ b/apps/frontend/src/app/features/roles/pages/roles-admin.page.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { RolesAdminPage } from './roles-admin.page';
+import { RolesAdminService } from '@features/roles/services/roles-admin.service';
+
+describe('RolesAdminPage', () => {
+  let fixture: ComponentFixture<RolesAdminPage>;
+  let component: RolesAdminPage;
+  let apiSpy: jasmine.SpyObj<RolesAdminService>;
+
+  beforeEach(async () => {
+    apiSpy = jasmine.createSpyObj<RolesAdminService>('RolesAdminService', [
+      'listUsers',
+      'createUser',
+      'updateUserRole',
+      'activateUser',
+      'deactivateUser',
+    ]);
+    apiSpy.listUsers.and.returnValue(
+      of([
+        {
+          id: 1,
+          email: 'manager@example.com',
+          first_name: 'Jane',
+          last_name: 'Doe',
+          role: 'manager',
+          is_active: true,
+        },
+      ]),
+    );
+    apiSpy.updateUserRole.and.returnValue(
+      of({
+        id: 1,
+        email: 'manager@example.com',
+        first_name: 'Jane',
+        last_name: 'Doe',
+        role: 'hr',
+        is_active: true,
+      }),
+    );
+    apiSpy.createUser.and.returnValue(
+      of({
+        id: 2,
+        email: 'new@example.com',
+        first_name: 'New',
+        last_name: 'User',
+        role: 'manager',
+        is_active: true,
+      }),
+    );
+    apiSpy.activateUser.and.returnValue(of({ status: 'user activated' }));
+    apiSpy.deactivateUser.and.returnValue(of({ status: 'user deactivated' }));
+
+    await TestBed.configureTestingModule({
+      imports: [RolesAdminPage],
+      providers: [{ provide: RolesAdminService, useValue: apiSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RolesAdminPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('auto-saves role when role dropdown changes', () => {
+    const event = {
+      target: {
+        value: 'hr',
+      },
+    } as unknown as Event;
+
+    component.onRoleChange(component.users[0], event);
+
+    expect(apiSpy.updateUserRole).toHaveBeenCalledWith(1, 'hr');
+  });
+});
+

--- a/apps/frontend/src/app/features/roles/pages/roles-admin.page.ts
+++ b/apps/frontend/src/app/features/roles/pages/roles-admin.page.ts
@@ -1,0 +1,132 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import {
+  AdminUser,
+  RolesAdminService,
+  UserRole,
+} from '@features/roles/services/roles-admin.service';
+
+const ROLE_OPTIONS: UserRole[] = [
+  'admin',
+  'hr',
+  'director',
+  'manager',
+  'employee',
+  'candidate',
+  'driver',
+];
+
+@Component({
+  standalone: true,
+  selector: 'app-roles-admin-page',
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './roles-admin.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RolesAdminPage {
+  private readonly api = inject(RolesAdminService);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly roleOptions = ROLE_OPTIONS;
+  users: AdminUser[] = [];
+  isLoading = true;
+  pageMessage: string | null = null;
+
+  readonly createForm = this.fb.nonNullable.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(8)]],
+    first_name: ['', [Validators.required]],
+    last_name: ['', [Validators.required]],
+    role: this.fb.nonNullable.control<UserRole>('manager', Validators.required),
+  });
+
+  constructor() {
+    this.loadUsers();
+  }
+
+  loadUsers(): void {
+    this.isLoading = true;
+    this.api
+      .listUsers()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (users) => {
+          this.users = users;
+          this.isLoading = false;
+        },
+        error: () => {
+          this.pageMessage = 'Unable to load users.';
+          this.isLoading = false;
+        },
+      });
+  }
+
+  createUser(): void {
+    if (this.createForm.invalid) {
+      this.createForm.markAllAsTouched();
+      return;
+    }
+    this.pageMessage = null;
+    this.api
+      .createUser(this.createForm.getRawValue())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.pageMessage = 'User created.';
+          this.createForm.reset({
+            email: '',
+            password: '',
+            first_name: '',
+            last_name: '',
+            role: 'manager',
+          });
+          this.loadUsers();
+        },
+        error: () => {
+          this.pageMessage = 'Unable to create user.';
+        },
+      });
+  }
+
+  onRoleChange(user: AdminUser, event: Event): void {
+    const target = event.target;
+    if (!(target instanceof HTMLSelectElement)) return;
+    const role = target.value as UserRole;
+    this.api
+      .updateUserRole(user.id, role)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.pageMessage = `Role updated for ${user.email}.`;
+          this.loadUsers();
+        },
+        error: () => {
+          this.pageMessage = `Unable to update role for ${user.email}.`;
+        },
+      });
+  }
+
+  toggleUser(user: AdminUser): void {
+    const req$ = user.is_active
+      ? this.api.deactivateUser(user.id)
+      : this.api.activateUser(user.id);
+
+    req$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => {
+        this.pageMessage = user.is_active
+          ? `${user.email} deactivated.`
+          : `${user.email} activated.`;
+        this.loadUsers();
+      },
+      error: () => {
+        this.pageMessage = `Unable to update active status for ${user.email}.`;
+      },
+    });
+  }
+}
+

--- a/apps/frontend/src/app/features/roles/services/roles-admin.service.spec.ts
+++ b/apps/frontend/src/app/features/roles/services/roles-admin.service.spec.ts
@@ -1,0 +1,58 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { RolesAdminService } from './roles-admin.service';
+
+describe('RolesAdminService', () => {
+  let service: RolesAdminService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [RolesAdminService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(RolesAdminService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('lists users', () => {
+    service.listUsers().subscribe((users) => {
+      expect(users.length).toBe(1);
+      expect(users[0].email).toBe('admin@example.com');
+    });
+
+    const req = httpMock.expectOne('/api/users/');
+    expect(req.request.method).toBe('GET');
+    req.flush([
+      {
+        id: 1,
+        email: 'admin@example.com',
+        first_name: 'Admin',
+        last_name: 'User',
+        role: 'admin',
+        is_active: true,
+      },
+    ]);
+  });
+
+  it('activates and deactivates user', () => {
+    service.deactivateUser(5).subscribe();
+    const deactivateReq = httpMock.expectOne('/api/users/5/deactivate/');
+    expect(deactivateReq.request.method).toBe('POST');
+    deactivateReq.flush({ status: 'user deactivated' });
+
+    service.activateUser(5).subscribe();
+    const activateReq = httpMock.expectOne('/api/users/5/activate/');
+    expect(activateReq.request.method).toBe('POST');
+    activateReq.flush({ status: 'user activated' });
+  });
+});
+

--- a/apps/frontend/src/app/features/roles/services/roles-admin.service.ts
+++ b/apps/frontend/src/app/features/roles/services/roles-admin.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export type UserRole =
+  | 'admin'
+  | 'hr'
+  | 'director'
+  | 'manager'
+  | 'employee'
+  | 'candidate'
+  | 'driver';
+
+export interface AdminUser {
+  id: number;
+  email: string;
+  first_name: string;
+  last_name: string;
+  role: UserRole;
+  is_active: boolean;
+}
+
+export interface CreateAdminUserPayload {
+  email: string;
+  password: string;
+  first_name: string;
+  last_name: string;
+  role: UserRole;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RolesAdminService {
+  private readonly http = inject(HttpClient);
+
+  listUsers(): Observable<AdminUser[]> {
+    return this.http.get<AdminUser[]>('/api/users/');
+  }
+
+  createUser(payload: CreateAdminUserPayload): Observable<AdminUser> {
+    return this.http.post<AdminUser>('/api/users/', {
+      ...payload,
+      is_active: true,
+    });
+  }
+
+  updateUserRole(userId: number, role: UserRole): Observable<AdminUser> {
+    return this.http.patch<AdminUser>(`/api/users/${userId}/`, { role });
+  }
+
+  activateUser(userId: number): Observable<{ status: string }> {
+    return this.http.post<{ status: string }>(`/api/users/${userId}/activate/`, {});
+  }
+
+  deactivateUser(userId: number): Observable<{ status: string }> {
+    return this.http.post<{ status: string }>(`/api/users/${userId}/deactivate/`, {});
+  }
+}
+

--- a/apps/frontend/src/app/features/tests/pages/tests-in-progress.page.html
+++ b/apps/frontend/src/app/features/tests/pages/tests-in-progress.page.html
@@ -1,0 +1,193 @@
+<section class="min-h-[calc(100vh-144px)] bg-slate-950 p-4 text-slate-100">
+  <header class="mb-4 flex items-center justify-between gap-3">
+    <div>
+      <h1 class="text-xl font-semibold">Tests in progress</h1>
+      <p class="text-sm text-slate-400">People currently being evaluated</p>
+    </div>
+
+    <a
+      routerLink="/positions"
+      class="rounded-xl border border-slate-700 px-3 py-2 text-xs text-slate-200 hover:bg-slate-800"
+    >
+      Back to positions
+    </a>
+  </header>
+
+  <div class="mb-4">
+    <input
+      type="search"
+      [formControl]="searchControl"
+      placeholder="Search candidate or position..."
+      class="w-full rounded-xl border border-slate-700 bg-slate-900 px-4 py-3 text-sm text-slate-100 outline-none focus:border-blue-500"
+    />
+  </div>
+
+  @if (isLoading) {
+    <p class="text-sm text-slate-400">Loading tests in progress...</p>
+  }
+
+  @if (!isLoading && errorMessage) {
+    <div class="rounded-xl border border-red-500/25 bg-red-500/10 p-3 text-sm text-red-200">
+      {{ errorMessage }}
+    </div>
+  }
+
+  @if (!isLoading && !errorMessage) {
+    @if (assignmentMessage) {
+      <div class="mb-3 rounded-xl border border-blue-500/25 bg-blue-500/10 p-3 text-sm text-blue-200">
+        {{ assignmentMessage }}
+      </div>
+    }
+
+    @if (groupedTests$ | async; as applications) {
+      <div class="space-y-3">
+        @for (application of applications; track application.applicationId) {
+          <article class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <h2 class="text-sm font-semibold">{{ application.candidateName }}</h2>
+                <p class="mt-1 text-xs text-slate-400">{{ application.candidateEmail }}</p>
+                <p class="text-xs text-slate-500">{{ application.positionTitle }}</p>
+              </div>
+
+              <span class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase text-emerald-300">
+                In progress
+              </span>
+            </div>
+
+            <p class="mt-3 text-xs text-slate-500">
+              Application #{{ application.applicationId }} • {{ application.evaluations.length }} template test(s)
+            </p>
+
+            <div class="mt-3 flex items-center gap-2">
+              <button
+                type="button"
+                class="rounded-lg border border-blue-500/40 px-3 py-2 text-xs font-semibold text-blue-200 hover:bg-blue-500/10"
+                (click)="openApplication(application.applicationId)"
+              >
+                Open test cards
+              </button>
+            </div>
+
+            @if (selectedApplicationId === application.applicationId) {
+              <div class="mt-4 grid gap-2 md:grid-cols-2">
+                @for (evaluation of application.evaluations; track evaluation.evaluationId) {
+                  <article class="rounded-xl border border-slate-700 bg-slate-900 px-3 py-3">
+                    <button
+                      type="button"
+                      class="w-full text-left hover:text-blue-200"
+                      (click)="openEvaluation(evaluation.evaluationId)"
+                    >
+                      <div class="text-xs text-slate-400">Template card</div>
+                      <div class="text-sm font-semibold">{{ evaluation.templateName }}</div>
+                      <div class="text-xs text-slate-500">
+                        Evaluation #{{ evaluation.evaluationId }}
+                      </div>
+                    </button>
+
+                    <div class="mt-3 space-y-2">
+                      <input
+                        type="search"
+                        [value]="managerSearchByEvaluation[evaluation.evaluationId] ?? ''"
+                        (input)="onManagerSearchInput(evaluation.evaluationId, $event)"
+                        placeholder="Search manager by name/email"
+                        class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100"
+                      />
+                      <select
+                        class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100"
+                        [value]="selectedManagerByEvaluation[evaluation.evaluationId] ?? ''"
+                        (change)="onSelectedManagerChange(evaluation.evaluationId, $event)"
+                      >
+                        <option value="">Select manager…</option>
+                        @for (
+                          manager of filteredManagers(evaluation.evaluationId);
+                          track manager.id
+                        ) {
+                          <option [value]="manager.id">
+                            {{ manager.full_name }} ({{ manager.email }})
+                          </option>
+                        }
+                      </select>
+                      <button
+                        type="button"
+                        class="rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white hover:bg-blue-500"
+                        (click)="assignSelectedManager(evaluation)"
+                      >
+                        Assign manager
+                      </button>
+                    </div>
+                  </article>
+                }
+              </div>
+            }
+          </article>
+        }
+
+        @if (applications.length === 0) {
+          <p class="text-sm text-slate-400">No tests are currently in progress.</p>
+        }
+      </div>
+    }
+
+    @if (managerLoadError) {
+      <div class="mt-3 rounded-xl border border-red-500/25 bg-red-500/10 p-3 text-sm text-red-200">
+        {{ managerLoadError }}
+      </div>
+    }
+
+    @if (selectedEvaluationId && questionnaire) {
+      <section class="mt-6 rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+        <h3 class="text-sm font-semibold text-slate-100">
+          Template: {{ questionnaire.template_name }} (Evaluation #{{ questionnaire.evaluation_id }})
+        </h3>
+
+        @if (questionnaireMessage) {
+          <div class="mt-2 rounded-lg border border-blue-500/25 bg-blue-500/10 p-2 text-xs text-blue-200">
+            {{ questionnaireMessage }}
+          </div>
+        }
+
+        <div class="mt-3 space-y-3">
+          @for (question of questionnaire.questions; track question.question_id; let i = $index) {
+            <article class="rounded-xl border border-slate-700 p-3">
+              <div class="text-xs text-slate-400">Question #{{ question.question_id }}</div>
+              <div class="text-sm font-semibold text-slate-100">{{ question.title }}</div>
+              <p class="mt-1 text-xs text-slate-300">{{ question.text }}</p>
+
+              <label class="mt-2 block text-xs text-slate-400" [attr.for]="'candidate-answer-' + i">
+                Candidate answer
+              </label>
+              <textarea
+                [id]="'candidate-answer-' + i"
+                class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100"
+                [value]="question.candidate_answer"
+                (input)="onQuestionAnswerInput(i, $event)"
+              ></textarea>
+
+              <label class="mt-2 block text-xs text-slate-400" [attr.for]="'manager-comment-' + i">
+                Manager comment
+              </label>
+              <textarea
+                [id]="'manager-comment-' + i"
+                class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-100"
+                [value]="question.manager_comment"
+                (input)="onQuestionCommentInput(i, $event)"
+              ></textarea>
+            </article>
+          }
+        </div>
+
+        <div class="mt-3">
+          <button
+            type="button"
+            class="rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white hover:bg-blue-500 disabled:opacity-60"
+            [disabled]="questionnaireSaving"
+            (click)="saveQuestionnaire()"
+          >
+            {{ questionnaireSaving ? 'Saving…' : 'Save answers and comments' }}
+          </button>
+        </div>
+      </section>
+    }
+  }
+</section>

--- a/apps/frontend/src/app/features/tests/pages/tests-in-progress.page.spec.ts
+++ b/apps/frontend/src/app/features/tests/pages/tests-in-progress.page.spec.ts
@@ -1,0 +1,159 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import {
+  InProgressTestItem,
+  ManagerOption,
+  PositionApplicantsService,
+} from '@features/positions/services/position-applicants.service';
+
+import { TestsInProgressPage } from './tests-in-progress.page';
+
+describe('TestsInProgressPage', () => {
+  let fixture: ComponentFixture<TestsInProgressPage>;
+  let component: TestsInProgressPage;
+  let applicantsServiceSpy: jasmine.SpyObj<PositionApplicantsService>;
+
+  const testsInProgress: InProgressTestItem[] = [
+    {
+      evaluationId: 41,
+      applicationId: 7,
+      candidateId: 15,
+      candidateName: 'Jane Doe',
+      candidateEmail: 'jane@example.com',
+      positionId: 9,
+      positionTitle: 'Linehaul Driver',
+      templateName: 'Template A',
+      updatedAt: '2026-04-09T10:00:00Z',
+    },
+  ];
+  const managers: ManagerOption[] = [
+    { id: 9, full_name: 'Alice Manager', email: 'alice.manager@example.com' },
+    { id: 12, full_name: 'Bob Manager', email: 'bob.manager@example.com' },
+  ];
+
+  beforeEach(async () => {
+    applicantsServiceSpy = jasmine.createSpyObj<PositionApplicantsService>(
+      'PositionApplicantsService',
+      [
+        'listInProgressTests',
+        'listManagers',
+        'assignManagerToEvaluation',
+        'getEvaluationQuestionnaire',
+        'saveEvaluationQuestionnaire',
+      ],
+    );
+
+    applicantsServiceSpy.listInProgressTests.and.returnValue(of(testsInProgress));
+    applicantsServiceSpy.listManagers.and.returnValue(of(managers));
+    applicantsServiceSpy.assignManagerToEvaluation.and.returnValue(
+      of({ id: 41, assigned_to: 9 }),
+    );
+    applicantsServiceSpy.getEvaluationQuestionnaire.and.returnValue(
+      of({
+        evaluation_id: 41,
+        template_name: 'Template A',
+        questions: [
+          {
+            question_id: 10,
+            title: 'Q1',
+            text: 'Question text',
+            is_mandatory: true,
+            points: 5,
+            candidate_answer: '',
+            manager_comment: '',
+            score: null,
+          },
+        ],
+      }),
+    );
+    applicantsServiceSpy.saveEvaluationQuestionnaire.and.returnValue(
+      of({
+        evaluation_id: 41,
+        template_name: 'Template A',
+        questions: [
+          {
+            question_id: 10,
+            title: 'Q1',
+            text: 'Question text',
+            is_mandatory: true,
+            points: 5,
+            candidate_answer: 'A',
+            manager_comment: 'C',
+            score: 4,
+          },
+        ],
+      }),
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [TestsInProgressPage],
+      providers: [{ provide: PositionApplicantsService, useValue: applicantsServiceSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestsInProgressPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('loads tests in progress', () => {
+    expect(applicantsServiceSpy.listInProgressTests).toHaveBeenCalledTimes(1);
+    expect(applicantsServiceSpy.listManagers).toHaveBeenCalledTimes(1);
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('filters tests by search query', (done) => {
+    component.searchControl.setValue('linehaul');
+
+    component.filteredTests$.subscribe((filteredTests) => {
+      expect(filteredTests.length).toBe(1);
+      expect(filteredTests[0].evaluationId).toBe(41);
+      done();
+    });
+  });
+
+  it('sets error message when API fails', async () => {
+    applicantsServiceSpy.listInProgressTests.and.returnValue(
+      throwError(() => new Error('failed')),
+    );
+
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [TestsInProgressPage],
+      providers: [{ provide: PositionApplicantsService, useValue: applicantsServiceSpy }],
+    }).compileComponents();
+
+    const errorFixture = TestBed.createComponent(TestsInProgressPage);
+    errorFixture.detectChanges();
+
+    expect(errorFixture.componentInstance.errorMessage).toBe(
+      'Unable to load ongoing tests.',
+    );
+  });
+
+  it('assigns manager selected from per-card manager selector', () => {
+    component.setManagerSearch(41, 'alice');
+    const filteredManagers = component.filteredManagers(41);
+    expect(filteredManagers.length).toBe(1);
+    expect(filteredManagers[0].id).toBe(9);
+
+    component.setSelectedManager(41, '9');
+    component.assignSelectedManager(testsInProgress[0]);
+
+    expect(applicantsServiceSpy.assignManagerToEvaluation).toHaveBeenCalledWith(41, 9);
+    expect(component.assignmentMessage).toContain('assigned');
+  });
+
+  it('opens evaluation questionnaire and saves answers/comments', () => {
+    component.openEvaluation(41);
+    expect(applicantsServiceSpy.getEvaluationQuestionnaire).toHaveBeenCalledWith(41);
+    expect(component.questionnaire?.questions.length).toBe(1);
+
+    component.updateQuestionAnswer(0, 'A');
+    component.updateQuestionComment(0, 'C');
+    component.saveQuestionnaire();
+
+    expect(applicantsServiceSpy.saveEvaluationQuestionnaire).toHaveBeenCalled();
+    expect(component.questionnaireMessage).toContain('saved');
+  });
+});

--- a/apps/frontend/src/app/features/tests/pages/tests-in-progress.page.ts
+++ b/apps/frontend/src/app/features/tests/pages/tests-in-progress.page.ts
@@ -1,0 +1,283 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { BehaviorSubject, combineLatest, map, startWith } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import {
+  EvaluationQuestionnaire,
+  InProgressTestItem,
+  ManagerOption,
+  PositionApplicantsService,
+} from '@features/positions/services/position-applicants.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-tests-in-progress-page',
+  imports: [CommonModule, RouterLink, ReactiveFormsModule],
+  templateUrl: './tests-in-progress.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TestsInProgressPage {
+  private readonly applicantsService = inject(PositionApplicantsService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly searchControl = new FormControl('', { nonNullable: true });
+
+  private readonly testsSubject = new BehaviorSubject<InProgressTestItem[]>([]);
+  readonly tests$ = this.testsSubject.asObservable();
+
+  readonly filteredTests$ = combineLatest([
+    this.tests$,
+    this.searchControl.valueChanges.pipe(startWith(this.searchControl.value)),
+  ]).pipe(
+    map(([testsInProgress, query]) => {
+      const normalized = query.trim().toLowerCase();
+      if (!normalized) {
+        return testsInProgress;
+      }
+
+      return testsInProgress.filter((item) => {
+        return (
+          item.candidateName.toLowerCase().includes(normalized) ||
+          item.candidateEmail.toLowerCase().includes(normalized) ||
+          item.positionTitle.toLowerCase().includes(normalized)
+        );
+      });
+    }),
+  );
+  readonly groupedTests$ = this.filteredTests$.pipe(
+    map((testsInProgress) => {
+      const mapByApplication = new Map<number, InProgressTestItem[]>();
+      for (const item of testsInProgress) {
+        const existing = mapByApplication.get(item.applicationId) ?? [];
+        existing.push(item);
+        mapByApplication.set(item.applicationId, existing);
+      }
+
+      return Array.from(mapByApplication.entries()).map(([applicationId, items]) => ({
+        applicationId,
+        candidateName: items[0].candidateName,
+        candidateEmail: items[0].candidateEmail,
+        positionTitle: items[0].positionTitle,
+        evaluations: items,
+      }));
+    }),
+  );
+
+  isLoading = true;
+  errorMessage: string | null = null;
+  assignmentMessage: string | null = null;
+  managerLoadError: string | null = null;
+  managers: ManagerOption[] = [];
+  managerSearchByEvaluation: Partial<Record<number, string>> = {};
+  selectedManagerByEvaluation: Partial<Record<number, string>> = {};
+  selectedApplicationId: number | null = null;
+  selectedEvaluationId: number | null = null;
+  questionnaire: EvaluationQuestionnaire | null = null;
+  questionnaireMessage: string | null = null;
+  questionnaireSaving = false;
+
+  constructor() {
+    this.loadManagers();
+    this.loadTestsInProgress();
+  }
+
+  private loadManagers(): void {
+    this.applicantsService
+      .listManagers()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (managers) => {
+          this.managers = managers;
+          this.managerLoadError = null;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.managers = [];
+          this.managerLoadError = 'Unable to load managers list.';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  private loadTestsInProgress(): void {
+    this.applicantsService
+      .listInProgressTests()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (testsInProgress) => {
+          this.testsSubject.next(testsInProgress);
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.errorMessage = 'Unable to load ongoing tests.';
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  assignManager(testItem: InProgressTestItem, managerIdRaw: string): void {
+    const managerId = Number(managerIdRaw);
+    if (!Number.isInteger(managerId) || managerId <= 0) {
+      this.assignmentMessage = 'Please enter a valid manager ID.';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    this.assignmentMessage = null;
+    this.applicantsService
+      .assignManagerToEvaluation(testItem.evaluationId, managerId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.assignmentMessage = `Manager #${managerId} assigned to evaluation #${testItem.evaluationId}.`;
+          this.loadTestsInProgress();
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.assignmentMessage = `Unable to assign manager #${managerId} to evaluation #${testItem.evaluationId}.`;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  setManagerSearch(evaluationId: number, value: string): void {
+    this.managerSearchByEvaluation = {
+      ...this.managerSearchByEvaluation,
+      [evaluationId]: value.trim(),
+    };
+  }
+
+  onManagerSearchInput(evaluationId: number, event: Event): void {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) {
+      return;
+    }
+    this.setManagerSearch(evaluationId, target.value);
+  }
+
+  setSelectedManager(evaluationId: number, value: string): void {
+    this.selectedManagerByEvaluation = {
+      ...this.selectedManagerByEvaluation,
+      [evaluationId]: value,
+    };
+  }
+
+  onSelectedManagerChange(evaluationId: number, event: Event): void {
+    const target = event.target;
+    if (!(target instanceof HTMLSelectElement)) {
+      return;
+    }
+    this.setSelectedManager(evaluationId, target.value);
+  }
+
+  filteredManagers(evaluationId: number): ManagerOption[] {
+    const query = (this.managerSearchByEvaluation[evaluationId] ?? '').toLowerCase();
+    if (!query) {
+      return this.managers;
+    }
+
+    return this.managers.filter((manager) => {
+      const blob = `${manager.full_name} ${manager.email}`.toLowerCase();
+      return blob.includes(query);
+    });
+  }
+
+  assignSelectedManager(testItem: InProgressTestItem): void {
+    const selected = this.selectedManagerByEvaluation[testItem.evaluationId];
+    this.assignManager(testItem, selected ?? '');
+  }
+
+  openApplication(applicationId: number): void {
+    this.selectedApplicationId = applicationId;
+    this.selectedEvaluationId = null;
+    this.questionnaire = null;
+    this.questionnaireMessage = null;
+  }
+
+  openEvaluation(evaluationId: number): void {
+    this.selectedEvaluationId = evaluationId;
+    this.questionnaire = null;
+    this.questionnaireMessage = null;
+    this.applicantsService
+      .getEvaluationQuestionnaire(evaluationId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (questionnaire) => {
+          this.questionnaire = questionnaire;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.questionnaireMessage = 'Unable to load template questions.';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  updateQuestionAnswer(index: number, value: string): void {
+    if (!this.questionnaire) return;
+    this.questionnaire.questions[index].candidate_answer = value;
+  }
+
+  updateQuestionComment(index: number, value: string): void {
+    if (!this.questionnaire) return;
+    this.questionnaire.questions[index].manager_comment = value;
+  }
+
+  onQuestionAnswerInput(index: number, event: Event): void {
+    const target = event.target;
+    if (!(target instanceof HTMLTextAreaElement)) {
+      return;
+    }
+    this.updateQuestionAnswer(index, target.value);
+  }
+
+  onQuestionCommentInput(index: number, event: Event): void {
+    const target = event.target;
+    if (!(target instanceof HTMLTextAreaElement)) {
+      return;
+    }
+    this.updateQuestionComment(index, target.value);
+  }
+
+  saveQuestionnaire(): void {
+    if (!this.questionnaire || this.selectedEvaluationId === null) return;
+
+    this.questionnaireSaving = true;
+    this.questionnaireMessage = null;
+    const answers = this.questionnaire.questions.map((question) => ({
+      question_id: question.question_id,
+      candidate_answer: question.candidate_answer,
+      manager_comment: question.manager_comment,
+      score: question.score,
+    }));
+
+    this.applicantsService
+      .saveEvaluationQuestionnaire(this.selectedEvaluationId, answers)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (payload) => {
+          this.questionnaire = payload;
+          this.questionnaireSaving = false;
+          this.questionnaireMessage = 'Questionnaire saved.';
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.questionnaireSaving = false;
+          this.questionnaireMessage = 'Unable to save questionnaire.';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+}

--- a/apps/frontend/src/app/features/tests/tests.routes.ts
+++ b/apps/frontend/src/app/features/tests/tests.routes.ts
@@ -1,0 +1,7 @@
+export const TESTS_ROUTES = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./pages/tests-in-progress.page').then((m) => m.TestsInProgressPage),
+  },
+];

--- a/docs/mvp-roadmap-step1.md
+++ b/docs/mvp-roadmap-step1.md
@@ -1,0 +1,82 @@
+# MVP Roadmap — Step 1 (Architecture Audit + Delivery Plan)
+
+## 1) Current architecture snapshot
+
+### Backend (Django + DRF)
+- Auth API exists for login (`/api/auth/login/`), me (`/api/auth/me/`), and refresh (`/api/auth/refresh/`).
+- Domain apps already exist for candidates, recruitment (job applications), positions, template grid, and evaluations.
+- Role enum currently includes: admin, hr, manager, director, employee.
+- Some role-based permissions exist (`IsHrAdminOrDirector`) but are not consistently applied across all sensitive endpoints.
+
+### Frontend internal app (Angular)
+- Has login page, token storage, auth guard, role guard, and auth interceptor.
+- Internal routes are already protected with auth + role checks for several feature areas.
+- Current login payload includes `profile` while backend login serializer authenticates with only email/password.
+
+### Candidate app (Angular)
+- Has jobs list, job detail, apply flow, and auth modal (sign in/sign up in modal).
+- Uses same backend auth endpoints and candidate creation endpoint.
+- Has own auth service and auth interceptor (separate from internal app auth foundation).
+
+## 2) Gaps vs target MVP
+
+1. **Shared authentication foundation is duplicated** between internal and candidate apps.
+2. **Role model mismatch** with requested MVP roles:
+   - requested: Admin/RH, Driver, Manager, Candidate
+   - current: admin, hr, manager, director, employee
+3. **Backend authorization coverage is incomplete**:
+   - some critical endpoints are open or missing strict object-level ownership checks.
+4. **Evaluation workflow exists at data level** but lacks end-to-end guarded flows for:
+   - launch test,
+   - manager section-only evaluation,
+   - final RH/Admin validation/rejection,
+   - controlled subject visibility.
+5. **Candidate history/results dashboard slice is not yet complete**.
+
+## 3) Ordered MVP implementation slices
+
+### Slice 1 — Baseline hardening + auth contract alignment
+- Align login contract between backend and both Angular apps.
+- Add missing register endpoint strategy (candidate-safe only).
+- Standardize token refresh and logout behavior.
+- Add backend permission coverage baseline tests.
+
+### Slice 2 — Role system normalization
+- Introduce explicit role mapping for `driver` and `candidate` while keeping backward compatibility where needed.
+- Add centralized backend role policy helpers.
+- Enforce role checks at API layer first (never frontend-only).
+
+### Slice 3 — Candidate portal complete flow
+- Public jobs list + job details + clean apply for authenticated and unauthenticated users.
+- Candidate account creation/login.
+- Candidate dashboard basics (applications + own evaluation history).
+
+### Slice 4 — Internal recruitment operations
+- Admin/RH job offer management hardening.
+- Launch test from candidate/driver context.
+- Link evaluation creation with application/user ownership and template version snapshot.
+
+### Slice 5 — Templates/tests minimal production flow
+- Ensure template + section + pool rules are reusable and validated.
+- Add mandatory question behavior enforcement if configured.
+- Add tests to protect template integrity and reusability.
+
+### Slice 6 — Manager partial evaluation flow
+- Section assignment API (manager can only read/write assigned section answers/comments).
+- Object-level permission checks for every manager write.
+- UI for manager section task queue and section form.
+
+### Slice 7 — Results, validation, decision
+- Subject view (candidate/driver): only allowed result fields/comments.
+- RH/Admin full review view.
+- RH/Admin validate/reject endpoint with audit fields and status transitions.
+
+### Slice 8 — Final MVP stabilization
+- End-to-end permission matrix test coverage.
+- CI parity checks with project GitHub Actions jobs.
+- Final UX consistency pass (dark design system, responsive behavior, shared UI reuse).
+
+## 4) Definition of done for Step 1
+- Existing architecture inspected.
+- MVP roadmap split into coherent, incremental vertical slices.
+- Next implementation step can start with Slice 1 only, using TDD.


### PR DESCRIPTION
### Motivation
- Expand evaluation capabilities with per-question responses and a launch/workflow so tests can be created from job applications and assigned to managers.
- Introduce explicit `driver` and `candidate` roles and tighten role-based access control across candidate, job application, evaluation and user admin APIs.
- Allow positions to declare ordered test templates with optional manager assignment so launches use position defaults when no explicit template is provided.
- Surface backend features in the internal frontend (positions, applicants, tests, roles) and align candidate auth to `GET /api/candidates/me/` for a consistent sign-in flow.

### Description
- Backend: add `UserRoles.DRIVER` and `UserRoles.CANDIDATE` and new role permissions `IsManager`, `IsCandidate`, `IsAdmin`; enforce roles across views for `Candidate`, `JobApplication`, `Evaluation`, `Position` and `User` endpoints.
- Candidate changes: set new user `role=UserRoles.CANDIDATE` on creation in `CandidateSerializer`; add `me` endpoint on `CandidateViewSet` (`GET /api/candidates/me/`) returning the authenticated candidate profile.
- Evaluations: add `EvaluationResponse` model + migration, expose questionnaire payload builder (`build_questionnaire_payload`), add `launch` endpoint (`POST /api/evaluations/launch/`), managers lookup (`GET /api/evaluations/managers/`), `questionnaire` read/save endpoints, and serializer/permission adjustments to scope querysets per role.
- Positions: add `PositionTestTemplateAssignment` model + migration and related serializers; add endpoints to get/put test-template assignments on a position (`/api/positions/{id}/test-templates/`) including safe handling when the table is missing (return `503`).
- Recruitment/job applications: scope listing/creation so candidates can only create/list their own applications and HR/admin can manage all; enforce permission checks in `JobApplicationViewSet` and `perform_create`.
- Users/admin: add `UserViewSet` with admin-only access, `activate`/`deactivate` actions, improved `UserSerializer` update behavior and email uniqueness handling, and permission class `IsAdmin`.
- Frontend (Angular internal & candidate): align auth flows to call `GET /api/candidates/me/` after login, map candidate-specific errors, add pages and services for tests in progress, applicants, positions template assignments, roles admin, and update existing components/services to support launching evaluations, manager assignment, questionnaire read/save and application counts; update many unit/spec tests accordingly.

### Testing
- Added and updated backend automated tests under `farid_tests` including integration tests for candidates, evaluations, job applications, positions and user admin flows, and unit tests for serializers; these tests were exercised as part of the change set.
- Added/updated frontend unit tests (Angular spec files) for auth, positions, applicants, tests-in-progress and roles admin services/pages to cover new behaviors and API contracts.
- Ran the automated test suites (backend `pytest` and frontend unit tests) against the modified code; all new and modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75d0559848328b58a3ed99397e8fe)